### PR TITLE
Fix context column definition

### DIFF
--- a/database/Migrations/CreateDB.php
+++ b/database/Migrations/CreateDB.php
@@ -24,7 +24,7 @@ class CreateDB implements Migration {
 		$sql = "CREATE TABLE {$table_name} (
         `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
         `option_key` VARCHAR(191) NOT NULL,
-        `context` NOT NULL DEFAULT,
+        `context` VARCHAR(191) NOT NULL DEFAULT '',
         `data` JSON DEFAULT NULL,
         `created` DATE NOT NULL,
         `expire` DATE DEFAULT NULL,


### PR DESCRIPTION
## Summary
- add explicit type and default for `context` column in migration

## Testing
- `php -l database/Migrations/CreateDB.php`
- `mysql -uwpuser -pwpPass123 wordpress -e "DROP TABLE IF EXISTS wp_boltaudit_options;" && mysql -uwpuser -pwpPass123 wordpress < /tmp/create.sql && mysql -uwpuser -pwpPass123 wordpress -e "SHOW TABLES LIKE 'wp_boltaudit_options';"`

------
https://chatgpt.com/codex/tasks/task_e_687bda6fce1483328bbd3338a8f48e34