### PR TITLE
Add plugin metrics collector and WP-CLI support

### DIFF
--- a/app/Console/PluginMetricsCommand.php
+++ b/app/Console/PluginMetricsCommand.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace BoltAudit\App\Console;
+
+use BoltAudit\App\Repositories\SinglePluginRepository;
+use WP_CLI;
+
+/**
+ * WP-CLI command to regenerate plugin metrics.
+ */
+class PluginMetricsCommand {
+    /**
+     * Execute the command.
+     */
+    public function __invoke() {
+        if ( ! function_exists( 'get_plugins' ) ) {
+            require_once ABSPATH . 'wp-admin/includes/plugin.php';
+        }
+
+        $all_plugins = get_plugins();
+        foreach ( $all_plugins as $plugin_file => $plugin_data ) {
+            $slug    = dirname( $plugin_file );
+            $version = $plugin_data['Version'] ?? 'unknown';
+            SinglePluginRepository::get_plugin_metrics( $slug, $version );
+            WP_CLI::log( "Regenerated metrics for {$slug}" );
+        }
+        WP_CLI::success( 'All plugin metrics regenerated.' );
+    }
+}

--- a/app/Repositories/SinglePluginRepository.php
+++ b/app/Repositories/SinglePluginRepository.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace BoltAudit\App\Repositories;
+
+use BoltAudit\App\Services\PluginMetricsCollector;
+use BoltAudit\App\Repositories\OptionsRepository;
+
+/**
+ * Repository for retrieving single plugin performance metrics.
+ */
+class SinglePluginRepository {
+    /**
+     * Cached collector instance.
+     */
+    protected static ?PluginMetricsCollector $collector = null;
+
+    /**
+     * Retrieve metrics for a plugin and cache them in the options table.
+     *
+     * @param string $slug    Plugin slug.
+     * @param string $version Plugin version.
+     * @return array<string,mixed>
+     */
+    public static function get_plugin_metrics( string $slug, string $version ): array {
+        $key    = "plugin_data_{$slug}_v{$version}";
+        $cached = OptionsRepository::get_option( $key, 'plugins_cache' );
+
+        if ( $cached && ! empty( $cached['data'] ) ) {
+            return json_decode( $cached['data'], true );
+        }
+
+        $collector = self::get_collector();
+        $metrics   = $collector->collect( $slug );
+
+        OptionsRepository::create_option( $key, 'plugins_cache', $metrics );
+
+        return $metrics;
+    }
+
+    /**
+     * Get or create metrics collector instance.
+     */
+    protected static function get_collector(): PluginMetricsCollector {
+        if ( ! self::$collector ) {
+            self::$collector = new PluginMetricsCollector();
+        }
+
+        return self::$collector;
+    }
+}

--- a/app/Services/PluginMetricsCollector.php
+++ b/app/Services/PluginMetricsCollector.php
@@ -1,0 +1,227 @@
+<?php
+
+namespace BoltAudit\App\Services;
+
+use ReflectionFunction;
+use ReflectionMethod;
+use WP_Scripts;
+use WP_Styles;
+
+/**
+ * Collects performance metrics for individual plugins.
+ */
+class PluginMetricsCollector {
+    /**
+     * Collect metrics for a given plugin slug.
+     *
+     * @param string $slug Plugin slug (directory name).
+     * @return array<string,mixed>
+     */
+    public function collect( string $slug ): array {
+        return [
+            'post_types'  => $this->get_registered_post_types( $slug ),
+            'scripts'     => $this->get_scripts_by_plugin( $slug ),
+            'styles'      => $this->get_styles_by_plugin( $slug ),
+            'hooks'       => $this->get_hooks_by_plugin( $slug ),
+            'cron_jobs'   => $this->get_cron_jobs_by_plugin( $slug ),
+            'query_count' => $this->get_plugin_query_count( $slug ),
+        ];
+    }
+
+    /**
+     * Determine if a path belongs to the plugin.
+     */
+    protected function belongs_to_plugin( ?string $path, string $slug ): bool {
+        if ( empty( $path ) ) {
+            return false;
+        }
+
+        $plugin_dir = trailingslashit( WP_PLUGIN_DIR ) . $slug . '/';
+
+        return strpos( wp_normalize_path( $path ), wp_normalize_path( $plugin_dir ) ) === 0;
+    }
+
+    /**
+     * Get the file path for a callback if possible.
+     *
+     * @param mixed $callback Callable callback.
+     */
+    protected function get_callback_file( $callback ): ?string {
+        try {
+            if ( is_string( $callback ) ) {
+                if ( strpos( $callback, '::' ) !== false ) {
+                    list( $class, $method ) = explode( '::', $callback );
+                    if ( class_exists( $class ) ) {
+                        $ref = new ReflectionMethod( $class, $method );
+                        return $ref->getFileName();
+                    }
+                } elseif ( function_exists( $callback ) ) {
+                    $ref = new ReflectionFunction( $callback );
+                    return $ref->getFileName();
+                }
+            } elseif ( is_array( $callback ) ) {
+                if ( is_object( $callback[0] ) ) {
+                    $ref = new ReflectionMethod( $callback[0], $callback[1] );
+                    return $ref->getFileName();
+                } elseif ( class_exists( $callback[0] ) ) {
+                    $ref = new ReflectionMethod( $callback[0], $callback[1] );
+                    return $ref->getFileName();
+                }
+            } elseif ( $callback instanceof \Closure ) {
+                $ref = new ReflectionFunction( $callback );
+                return $ref->getFileName();
+            }
+        } catch ( \ReflectionException $e ) {
+            return null;
+        }
+
+        return null;
+    }
+
+    /**
+     * Count hooks added by plugin.
+     */
+    public function get_hooks_by_plugin( string $slug ): int {
+        global $wp_filter;
+
+        $count = 0;
+        foreach ( (array) $wp_filter as $hook ) {
+            if ( empty( $hook->callbacks ) ) {
+                continue;
+            }
+            foreach ( $hook->callbacks as $callbacks ) {
+                foreach ( $callbacks as $callback ) {
+                    $file = $this->get_callback_file( $callback['function'] );
+                    if ( $this->belongs_to_plugin( $file, $slug ) ) {
+                        $count++;
+                    }
+                }
+            }
+        }
+
+        return $count;
+    }
+
+    /**
+     * Get registered scripts by plugin.
+     */
+    public function get_scripts_by_plugin( string $slug ): array {
+        global $wp_scripts;
+
+        if ( ! $wp_scripts instanceof WP_Scripts ) {
+            return [];
+        }
+
+        $scripts = [];
+        foreach ( $wp_scripts->registered as $handle => $data ) {
+            $src = $data->src;
+            if ( strpos( $src, "/{$slug}/" ) !== false ) {
+                $scripts[] = [
+                    'handle' => $handle,
+                    'src'    => $src,
+                ];
+            }
+        }
+
+        return $scripts;
+    }
+
+    /**
+     * Get registered styles by plugin.
+     */
+    public function get_styles_by_plugin( string $slug ): array {
+        global $wp_styles;
+
+        if ( ! $wp_styles instanceof WP_Styles ) {
+            return [];
+        }
+
+        $styles = [];
+        foreach ( $wp_styles->registered as $handle => $data ) {
+            $src = $data->src;
+            if ( strpos( $src, "/{$slug}/" ) !== false ) {
+                $styles[] = [
+                    'handle' => $handle,
+                    'src'    => $src,
+                ];
+            }
+        }
+
+        return $styles;
+    }
+
+    /**
+     * Get custom post types registered by plugin.
+     */
+    public function get_registered_post_types( string $slug ): array {
+        $types = [];
+        foreach ( get_post_types( ['_builtin' => false], 'objects' ) as $cpt ) {
+            $match = false;
+            if ( false !== strpos( $cpt->name, $slug ) ) {
+                $match = true;
+            } elseif ( ! empty( $cpt->rewrite['slug'] ) && false !== strpos( $cpt->rewrite['slug'], $slug ) ) {
+                $match = true;
+            } elseif ( ! empty( $cpt->rest_base ) && false !== strpos( $cpt->rest_base, $slug ) ) {
+                $match = true;
+            }
+
+            if ( $match ) {
+                $types[] = $cpt->name;
+            }
+        }
+
+        return $types;
+    }
+
+    /**
+     * Get cron jobs scheduled by plugin.
+     */
+    public function get_cron_jobs_by_plugin( string $slug ): array {
+        $cron = _get_cron_array();
+        if ( empty( $cron ) ) {
+            return [];
+        }
+
+        $jobs = [];
+        foreach ( $cron as $timestamp => $hooks ) {
+            foreach ( $hooks as $hook => $events ) {
+                foreach ( $events as $event ) {
+                    $file = $this->get_callback_file( $event['function'] );
+                    if ( $this->belongs_to_plugin( $file, $slug ) ) {
+                        $jobs[] = [
+                            'hook'     => $hook,
+                            'schedule' => $event['schedule'] ?? 'single',
+                        ];
+                        break;
+                    }
+                }
+            }
+        }
+
+        return $jobs;
+    }
+
+    /**
+     * Count queries executed by the plugin. Requires SAVEQUERIES.
+     */
+    public function get_plugin_query_count( string $slug ): int {
+        global $wpdb;
+
+        if ( ! defined( 'SAVEQUERIES' ) || ! SAVEQUERIES || empty( $wpdb->queries ) ) {
+            return 0;
+        }
+
+        $count = 0;
+        foreach ( $wpdb->queries as $query ) {
+            $trace = $query[2] ?? [];
+            foreach ( $trace as $step ) {
+                if ( ! empty( $step['file'] ) && $this->belongs_to_plugin( $step['file'], $slug ) ) {
+                    $count++;
+                    break;
+                }
+            }
+        }
+
+        return $count;
+    }
+}

--- a/boltaudit.php
+++ b/boltaudit.php
@@ -3,6 +3,8 @@
 defined( 'ABSPATH' ) || exit;
 
 use BoltAudit\WpMVC\App;
+use BoltAudit\App\Console\PluginMetricsCommand;
+use WP_CLI;
 
 /**
  * Plugin Name:       BoltAudit – Performance Audit Advisor
@@ -62,3 +64,7 @@ final class BoltAudit {
 }
 
 BoltAudit::instance()->load();
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+    WP_CLI::add_command( 'boltaudit regenerate plugin-metrics', PluginMetricsCommand::class );
+}
+


### PR DESCRIPTION
## Summary
- add a service for collecting plugin level metrics
- create repository to store plugin metrics
- introduce optional WP‑CLI command to regenerate metrics
- register the CLI command in the plugin bootstrap

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bc5735cb8833294a1549434ad0611