### PR TITLE
Fix plugin repo collector init

### DIFF
--- a/app/Repositories/EnvironmentRepository.php
+++ b/app/Repositories/EnvironmentRepository.php
@@ -2,130 +2,135 @@
 
 namespace BoltAudit\App\Repositories;
 
+defined( 'ABSPATH' ) || exit;
+
 class EnvironmentRepository {
+    public static function get_php_version() {
+        return phpversion();
+    }
 
-	public static function get_php_version() {
-		return phpversion();
-	}
+    public static function get_php_sapi() {
+        return php_sapi_name();
+    }
 
-	public static function get_php_sapi() {
-		return php_sapi_name();
-	}
+    public static function get_php_user() {
+        return get_current_user();
+    }
 
-	public static function get_php_user() {
-		return get_current_user();
-	}
+    public static function get_php_ini_values() {
+        return [
+            'max_execution_time'  => ini_get( 'max_execution_time' ),
+            'memory_limit'        => ini_get( 'memory_limit' ),
+            'upload_max_filesize' => ini_get( 'upload_max_filesize' ),
+            'post_max_size'       => ini_get( 'post_max_size' ),
+            'display_errors'      => ini_get( 'display_errors' ),
+            'log_errors'          => ini_get( 'log_errors' ),
+        ];
+    }
 
-	public static function get_php_ini_values() {
-		return [
-			'max_execution_time'  => ini_get( 'max_execution_time' ),
-			'memory_limit'        => ini_get( 'memory_limit' ),
-			'upload_max_filesize' => ini_get( 'upload_max_filesize' ),
-			'post_max_size'       => ini_get( 'post_max_size' ),
-			'display_errors'      => ini_get( 'display_errors' ),
-			'log_errors'          => ini_get( 'log_errors' ),
-		];
-	}
+    public static function get_php_extensions() {
+        $extensions = get_loaded_extensions();
+        sort( $extensions );
 
-	public static function get_php_extensions() {
-		$extensions = get_loaded_extensions();
-		sort( $extensions );
+        return $extensions;
+    }
 
-		return $extensions;
-	}
+    public static function get_php_error_reporting() {
+        return error_reporting();
+    }
 
-	public static function get_php_error_reporting() {
-		return error_reporting();
-	}
+    public static function get_server_software() {
+            return isset( $_SERVER['SERVER_SOFTWARE'] )
+                    ? sanitize_text_field( wp_unslash( $_SERVER['SERVER_SOFTWARE'] ) )
+                    : null;
+    }
 
-	public static function get_server_software() {
-		return $_SERVER['SERVER_SOFTWARE'] ?? null;
-	}
+    public static function get_server_address() {
+            return isset( $_SERVER['SERVER_ADDR'] )
+                    ? sanitize_text_field( wp_unslash( $_SERVER['SERVER_ADDR'] ) )
+                    : null;
+    }
 
-	public static function get_server_address() {
-		return $_SERVER['SERVER_ADDR'] ?? null;
-	}
+    public static function get_server_os() {
+        return function_exists( 'php_uname' ) ? php_uname( 's' ) . ' ' . php_uname( 'r' ) : null;
+    }
 
-	public static function get_server_os() {
-		return function_exists( 'php_uname' ) ? php_uname( 's' ) . ' ' . php_uname( 'r' ) : null;
-	}
+    public static function get_server_host() {
+        return function_exists( 'php_uname' ) ? php_uname( 'n' ) : null;
+    }
 
-	public static function get_server_host() {
-		return function_exists( 'php_uname' ) ? php_uname( 'n' ) : null;
-	}
+    public static function get_server_arch() {
+        return function_exists( 'php_uname' ) ? php_uname( 'm' ) : null;
+    }
 
-	public static function get_server_arch() {
-		return function_exists( 'php_uname' ) ? php_uname( 'm' ) : null;
-	}
+    public static function get_wordpress_version() {
+        global $wp_version;
 
-	public static function get_wordpress_version() {
-		global $wp_version;
+        return $wp_version ?? null;
+    }
 
-		return $wp_version ?? null;
-	}
+    public static function get_wordpress_constants() {
+        return [
+            'WP_DEBUG'            => defined( 'WP_DEBUG' ) ? WP_DEBUG : null,
+            'WP_DEBUG_DISPLAY'    => defined( 'WP_DEBUG_DISPLAY' ) ? WP_DEBUG_DISPLAY : null,
+            'WP_DEBUG_LOG'        => defined( 'WP_DEBUG_LOG' ) ? WP_DEBUG_LOG : null,
+            'SCRIPT_DEBUG'        => defined( 'SCRIPT_DEBUG' ) ? SCRIPT_DEBUG : null,
+            'WP_CACHE'            => defined( 'WP_CACHE' ) ? WP_CACHE : null,
+            'CONCATENATE_SCRIPTS' => defined( 'CONCATENATE_SCRIPTS' ) ? constant( 'CONCATENATE_SCRIPTS' ) : null,
+            'COMPRESS_SCRIPTS'    => defined( 'COMPRESS_SCRIPTS' ) ? constant( 'COMPRESS_SCRIPTS' ) : null,
+            'COMPRESS_CSS'        => defined( 'COMPRESS_CSS' ) ? constant( 'COMPRESS_CSS' ) : null,
+        ];
+    }
 
-	public static function get_wordpress_constants() {
-		return [
-			'WP_DEBUG'            => defined( 'WP_DEBUG' ) ? WP_DEBUG : null,
-			'WP_DEBUG_DISPLAY'    => defined( 'WP_DEBUG_DISPLAY' ) ? WP_DEBUG_DISPLAY : null,
-			'WP_DEBUG_LOG'        => defined( 'WP_DEBUG_LOG' ) ? WP_DEBUG_LOG : null,
-			'SCRIPT_DEBUG'        => defined( 'SCRIPT_DEBUG' ) ? SCRIPT_DEBUG : null,
-			'WP_CACHE'            => defined( 'WP_CACHE' ) ? WP_CACHE : null,
-			'CONCATENATE_SCRIPTS' => defined( 'CONCATENATE_SCRIPTS' ) ? constant( 'CONCATENATE_SCRIPTS' ) : null,
-			'COMPRESS_SCRIPTS'    => defined( 'COMPRESS_SCRIPTS' ) ? constant( 'COMPRESS_SCRIPTS' ) : null,
-			'COMPRESS_CSS'        => defined( 'COMPRESS_CSS' ) ? constant( 'COMPRESS_CSS' ) : null,
-		];
-	}
+    public static function get_environment_type() {
+        return function_exists( 'wp_get_environment_type' ) ? wp_get_environment_type() : 'production';
+    }
 
-	public static function get_environment_type() {
-		return function_exists( 'wp_get_environment_type' ) ? wp_get_environment_type() : 'production';
-	}
+    public static function get_development_mode() {
+        return function_exists( 'wp_get_development_mode' ) ? wp_get_development_mode() : null;
+    }
 
-	public static function get_development_mode() {
-		return function_exists( 'wp_get_development_mode' ) ? wp_get_development_mode() : null;
-	}
+    public static function get_database_info() {
+        global $wpdb;
 
-	public static function get_database_info() {
-		global $wpdb;
+        if ( ! $wpdb ) {
+            return [];
+        }
 
-		if ( ! $wpdb ) {
-			return [];
-		}
+        $server_version = $wpdb->get_var( 'SELECT VERSION()' );
 
-		$server_version = $wpdb->get_var( 'SELECT VERSION()' );
+        return [
+            'database_name'  => $wpdb->dbname,
+            'database_user'  => $wpdb->dbuser,
+            'database_host'  => $wpdb->dbhost,
+            'server_version' => $server_version,
+        ];
+    }
 
-		return [
-			'database_name'  => $wpdb->dbname,
-			'database_user'  => $wpdb->dbuser,
-			'database_host'  => $wpdb->dbhost,
-			'server_version' => $server_version,
-		];
-	}
-
-	public static function get_all() {
-		return [
-			'php'       => [
-				'version'         => self::get_php_version(),
-				'sapi'            => self::get_php_sapi(),
-				'user'            => self::get_php_user(),
-				'ini_values'      => self::get_php_ini_values(),
-				'extensions'      => self::get_php_extensions(),
-				'error_reporting' => self::get_php_error_reporting(),
-			],
-			'server'    => [
-				'software' => self::get_server_software(),
-				'address'  => self::get_server_address(),
-				'os'       => self::get_server_os(),
-				'host'     => self::get_server_host(),
-				'arch'     => self::get_server_arch(),
-			],
-			'wordpress' => [
-				'version'          => self::get_wordpress_version(),
-				'constants'        => self::get_wordpress_constants(),
-				'environment_type' => self::get_environment_type(),
-				'development_mode' => self::get_development_mode(),
-			],
-			'database'  => self::get_database_info(),
-		];
-	}
+    public static function get_all() {
+        return [
+            'php'       => [
+                'version'         => self::get_php_version(),
+                'sapi'            => self::get_php_sapi(),
+                'user'            => self::get_php_user(),
+                'ini_values'      => self::get_php_ini_values(),
+                'extensions'      => self::get_php_extensions(),
+                'error_reporting' => self::get_php_error_reporting(),
+            ],
+            'server'    => [
+                'software' => self::get_server_software(),
+                'address'  => self::get_server_address(),
+                'os'       => self::get_server_os(),
+                'host'     => self::get_server_host(),
+                'arch'     => self::get_server_arch(),
+            ],
+            'wordpress' => [
+                'version'          => self::get_wordpress_version(),
+                'constants'        => self::get_wordpress_constants(),
+                'environment_type' => self::get_environment_type(),
+                'development_mode' => self::get_development_mode(),
+            ],
+            'database'  => self::get_database_info(),
+        ];
+    }
 }

--- a/app/Repositories/SinglePluginRepository.php
+++ b/app/Repositories/SinglePluginRepository.php
@@ -5,128 +5,142 @@ namespace BoltAudit\App\Repositories;
 use BoltAudit\App\Repositories\OptionsRepository;
 use BoltAudit\App\Services\PluginMetricsCollector;
 
+defined( 'ABSPATH' ) || exit;
+
 /**
  * Repository for retrieving single plugin performance metrics.
  */
 class SinglePluginRepository {
-	/**
-	 * Cached collector instance.
-	 */
-	protected static PluginMetricsCollector $collector;
+       /**
+        * Cached collector instance.
+        *
+        * @var PluginMetricsCollector|null
+        */
+    protected static ?PluginMetricsCollector $collector = null;
 
-	protected static $active_plugins = [];
-	protected static $plugin_updates = [];
+    protected static $active_plugins = [];
 
-	public static function get_plugin_data( $plugin_file, $plugin_data ) {
+    protected static $plugin_updates = [];
 
-		if ( ! function_exists( 'get_plugins' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/plugin.php';
-		}
+       /**
+        * Load WordPress plugin utility functions and cache plugin state.
+        */
+    protected static function ensure_wp_functions(): void {
+        if ( ! function_exists( 'get_plugins' ) ) {
+               require_once ABSPATH . 'wp-admin/includes/plugin.php';
+        }
 
-		if ( ! function_exists( 'get_plugin_updates' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/update.php';
-		}
+        if ( ! function_exists( 'get_plugin_updates' ) ) {
+                  require_once ABSPATH . 'wp-admin/includes/update.php';
+        }
 
-		self::$plugin_updates = get_plugin_updates();
-		self::$active_plugins = get_option( 'active_plugins', [] );
+            self::$plugin_updates = get_plugin_updates();
+            self::$active_plugins = get_option( 'active_plugins', [] );
+    }
 
-		$slug         = dirname( $plugin_file );
-		$version      = $plugin_data['Version'] ?? 'unknown';
-		$option_key   = "plugin_data_{$slug}_v{$version}";
-		$cached_entry = OptionsRepository::get_option( $option_key, 'plugins_cache' );
+    public static function get_plugin_data( $plugin_file, $plugin_data ) {
 
-		if ( $cached_entry && ! empty( $cached_entry['data'] ) ) {
-			return json_decode( $cached_entry['data'], true );
-		}
+            // Ensure WordPress plugin helpers are loaded only once.
+            self::ensure_wp_functions();
 
-		$wp_org_info  = self::fetch_wp_org_info( $slug );
-		$is_wp_repo   = ! empty( $wp_org_info ) && ! is_wp_error( $wp_org_info );
-		$last_updated = $is_wp_repo ? ( $wp_org_info->last_updated ?? null ) : null;
-		$is_abandoned = $last_updated ? self::is_abandoned( $last_updated ) : null;
+        $slug         = dirname( $plugin_file );
+        $version      = $plugin_data['Version'] ?? 'unknown';
+        $option_key   = "plugin_data_{$slug}_v{$version}";
+        $cached_entry = OptionsRepository::get_option( $option_key, 'plugins_cache' );
 
-		$data = [
-			'name'          => $plugin_data['Name'] ?? '',
-			'slug'          => $slug,
-			'plugin_file'   => $plugin_file,
-			'needs_upgrade' => isset( $plugin_updates[$plugin_file] ),
-			'is_wp_repo'    => $is_wp_repo,
-			'is_active'     => in_array( $plugin_file, self::$active_plugins ),
-			'last_updated'  => $last_updated,
-			'is_abandoned'  => $is_abandoned,
-			'version'       => $version,
-		];
+        if ( $cached_entry && ! empty( $cached_entry['data'] ) ) {
+            return json_decode( $cached_entry['data'], true );
+        }
 
-		OptionsRepository::create_option( $option_key, 'plugins_cache', $data );
+        $wp_org_info  = self::fetch_wp_org_info( $slug );
+        $is_wp_repo   = ! empty( $wp_org_info ) && ! is_wp_error( $wp_org_info );
+        $last_updated = $is_wp_repo ? ( $wp_org_info->last_updated ?? null ) : null;
+        $is_abandoned = $last_updated ? self::is_abandoned( $last_updated ) : null;
 
-		return $data;
-	}
+        $data = [
+            'name'          => $plugin_data['Name'] ?? '',
+            'slug'          => $slug,
+            'plugin_file'   => $plugin_file,
+            'needs_upgrade' => isset( $plugin_updates[$plugin_file] ),
+            'is_wp_repo'    => $is_wp_repo,
+            'is_active'     => in_array( $plugin_file, self::$active_plugins ),
+            'last_updated'  => $last_updated,
+            'is_abandoned'  => $is_abandoned,
+            'version'       => $version,
+        ];
 
-	/**
-	 * Retrieve metrics for a plugin and cache them in the options table.
-	 *
-	 * @param string $slug    Plugin slug.
-	 * @param string $version Plugin version.
-	 * @return array<string,mixed>
-	 */
-	public static function get_plugin_page_data( string $slug, string $version ): array {
-		$key    = "plugin_data_{$slug}_v{$version}";
-		$cached = OptionsRepository::get_option( $key, 'plugins_cache' );
+        OptionsRepository::create_option( $option_key, 'plugins_cache', $data );
 
-		if ( $cached && ! empty( $cached['data']['hooks'] ) ) {
-			return json_decode( $cached['data'], true );
-		}
+        return $data;
+    }
 
-		$collector = self::get_collector();
-		$data      = $collector->collect( $slug );
-		if ( is_array( $cached ) ) {
-			$data = array_merge( $cached, $data );
-		}
+    /**
+     * Retrieve metrics for a plugin and cache them in the options table.
+     *
+     * @param string $slug    Plugin slug.
+     * @param string $version Plugin version.
+     * @return array<string,mixed>
+     */
+    public static function get_plugin_page_data( string $slug, string $version ): array {
+        $key    = "plugin_data_{$slug}_v{$version}";
+        $cached = OptionsRepository::get_option( $key, 'plugins_cache' );
 
-		OptionsRepository::create_option( $key, 'plugins_cache', $data );
+        if ( $cached && ! empty( $cached['data']['hooks'] ) ) {
+            return json_decode( $cached['data'], true );
+        }
 
-		return $data;
-	}
+        $collector = self::get_collector();
+        $data      = $collector->collect( $slug );
+        if ( is_array( $cached ) ) {
+            $data = array_merge( $cached, $data );
+        }
 
-	protected static function is_wp_org_plugin( $plugin ) {
-		foreach ( ['PluginURI', 'AuthorURI'] as $key ) {
-			if ( ! empty( $plugin[$key] ) && strpos( $plugin[$key], 'wordpress.org' ) !== false ) {
-				return true;
-			}
-		}
+        OptionsRepository::create_option( $key, 'plugins_cache', $data );
 
-		return false;
-	}
+        return $data;
+    }
 
-	protected static function fetch_wp_org_info( $slug ) {
-		if ( ! function_exists( 'plugins_api' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
-		}
+    protected static function is_wp_org_plugin( $plugin ) {
+        foreach ( ['PluginURI', 'AuthorURI'] as $key ) {
+            if ( ! empty( $plugin[$key] ) && strpos( $plugin[$key], 'wordpress.org' ) !== false ) {
+                return true;
+            }
+        }
 
-		$info = plugins_api( 'plugin_information', ['slug' => $slug, 'fields' => ['last_updated' => true]] );
-		if ( is_wp_error( $info ) ) {
-			return;
-		}
+        return false;
+    }
 
-		return $info;
-	}
+    protected static function fetch_wp_org_info( $slug ) {
+        if ( ! function_exists( 'plugins_api' ) ) {
+            require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
+        }
 
-	protected static function is_abandoned( $last_updated ) {
-		$then = strtotime( $last_updated );
-		if ( ! $then ) {
-			return false;
-		}
+        $info = plugins_api( 'plugin_information', ['slug' => $slug, 'fields' => ['last_updated' => true]] );
+        if ( is_wp_error( $info ) ) {
+            return;
+        }
 
-		return ( time() - $then ) > YEAR_IN_SECONDS;
-	}
+        return $info;
+    }
 
-	/**
-	 * Get or create data collector instance.
-	 */
-	protected static function get_collector(): PluginMetricsCollector {
-		if ( ! self::$collector ) {
-			self::$collector = new PluginMetricsCollector();
-		}
+    protected static function is_abandoned( $last_updated ) {
+        $then = strtotime( $last_updated );
+        if ( ! $then ) {
+            return false;
+        }
 
-		return self::$collector;
-	}
+        return ( time() - $then ) > YEAR_IN_SECONDS;
+    }
+
+    /**
+     * Get or create data collector instance.
+     */
+    protected static function get_collector(): PluginMetricsCollector {
+            // Lazily instantiate the collector when first needed.
+        if ( null === self::$collector ) {
+               self::$collector = new PluginMetricsCollector();
+        }
+
+            return self::$collector;
+    }
 }


### PR DESCRIPTION
## Summary
- prevent direct file access and add plugin caching helper
- sanitize `$_SERVER` variables and add ABSPATH check
- lazy load metrics collector

## Testing
- `vendor-src/bin/phpcbf --standard=dev-tools/phpcs.xml app/Repositories/SinglePluginRepository.php app/Repositories/EnvironmentRepository.php`
- `vendor-src/bin/phpcs --standard=dev-tools/phpcs.xml app/Repositories/SinglePluginRepository.php app/Repositories/EnvironmentRepository.php`

------
https://chatgpt.com/codex/tasks/task_e_687bec2f38d883328e0ed73759915da2