### PR TITLE
Capture custom post type registration sources

### DIFF
--- a/app/Services/PluginMetricsCollector.php
+++ b/app/Services/PluginMetricsCollector.php
@@ -4,161 +4,187 @@ namespace BoltAudit\App\Services;
 
 use ReflectionFunction;
 use ReflectionMethod;
+use BoltAudit\App\Services\PostTypeTracker;
 
 /**
  * Collects performance metrics for individual plugins.
  */
-class PluginMetricsCollector {
-	protected string $slug;
+class PluginMetricsCollector
+{
+    protected string $slug;
 
-	public function run( string $slug ): array {
-		$this->slug = $slug;
+    public function run( string $slug ): array
+    {
+        $this->slug = $slug;
 
-		return $this->collect_now();
-	}
+        return $this->collect_now();
+    }
 
-	protected function collect_now(): array {
-		return [
-			'post_types'  => $this->get_registered_post_types(),
-			'scripts'     => $this->get_scripts_by_plugin(),
-			'styles'      => $this->get_styles_by_plugin(),
-			'hooks'       => $this->get_hooks_by_plugin(),
-			'cron_jobs'   => $this->get_cron_jobs_by_plugin(),
-			'query_count' => $this->get_plugin_query_count(),
-		];
-	}
+    protected function collect_now(): array
+    {
+        return [
+        'post_types'  => $this->get_registered_post_types(),
+        'scripts'     => $this->get_scripts_by_plugin(),
+        'styles'      => $this->get_styles_by_plugin(),
+        'hooks'       => $this->get_hooks_by_plugin(),
+        'cron_jobs'   => $this->get_cron_jobs_by_plugin(),
+        'query_count' => $this->get_plugin_query_count(),
+        ];
+    }
 
-	protected function belongs_to_plugin( string $path ): bool {
-		if ( empty( $path ) ) {
-			return false;
-		}
+    protected function belongs_to_plugin( string $path ): bool
+    {
+        if (empty($path) ) {
+            return false;
+        }
 
-		$plugin_dir = wp_normalize_path( WP_PLUGIN_DIR . '/' . $this->slug );
+        $plugin_dir = wp_normalize_path(WP_PLUGIN_DIR . '/' . $this->slug);
 
-		return strpos( wp_normalize_path( $path ), $plugin_dir ) === 0;
-	}
+        return strpos(wp_normalize_path($path), $plugin_dir) === 0;
+    }
 
-	protected function get_callback_file( $callback ) {
-		try {
-			if ( is_string( $callback ) ) {
-				if ( strpos( $callback, '::' ) !== false ) {
-					list( $class, $method ) = explode( '::', $callback );
-					if ( class_exists( $class ) ) {
-						$ref = new ReflectionMethod( $class, $method );
+    protected function get_callback_file( $callback )
+    {
+        try {
+            if (is_string($callback) ) {
+                if (strpos($callback, '::') !== false ) {
+                    list( $class, $method ) = explode('::', $callback);
+                    if (class_exists($class) ) {
+                        $ref = new ReflectionMethod($class, $method);
 
-						return $ref->getFileName();
-					}
-				} elseif ( function_exists( $callback ) ) {
-					$ref = new ReflectionFunction( $callback );
+                        return $ref->getFileName();
+                    }
+                } elseif (function_exists($callback) ) {
+                    $ref = new ReflectionFunction($callback);
 
-					return $ref->getFileName();
-				}
-			} elseif ( is_array( $callback ) ) {
-				if ( is_object( $callback[0] ) || class_exists( $callback[0] ) ) {
-					$ref = new ReflectionMethod( $callback[0], $callback[1] );
+                    return $ref->getFileName();
+                }
+            } elseif (is_array($callback) ) {
+                if (is_object($callback[0]) || class_exists($callback[0]) ) {
+                    $ref = new ReflectionMethod($callback[0], $callback[1]);
 
-					return $ref->getFileName();
-				}
-			} elseif ( $callback instanceof \Closure ) {
-				$ref = new ReflectionFunction( $callback );
+                    return $ref->getFileName();
+                }
+            } elseif ($callback instanceof \Closure ) {
+                $ref = new ReflectionFunction($callback);
 
-				return $ref->getFileName();
-			}
-		} catch ( \ReflectionException $e ) {}
+                return $ref->getFileName();
+            }
+        } catch ( \ReflectionException $e ) {
+        }
 
-		return;
-	}
+        return;
+    }
 
-	public function get_hooks_by_plugin(): int {
-		global $wp_filter;
-		$count = 0;
-		foreach ( $wp_filter as $hook ) {
-			foreach ( $hook->callbacks ?? [] as $callbacks ) {
-				foreach ( $callbacks as $callback ) {
-					$file = $this->get_callback_file( $callback['function'] ) ?? '';
-					if ( $this->belongs_to_plugin( $file ) ) {
-						$count++;
-					}
-				}
-			}
-		}
+    public function get_hooks_by_plugin(): int
+    {
+        global $wp_filter;
+        $count = 0;
+        foreach ( $wp_filter as $hook ) {
+            foreach ( $hook->callbacks ?? [] as $callbacks ) {
+                foreach ( $callbacks as $callback ) {
+                    $file = $this->get_callback_file($callback['function']) ?? '';
+                    if ($this->belongs_to_plugin($file) ) {
+                        $count++;
+                    }
+                }
+            }
+        }
 
-		return $count;
-	}
+        return $count;
+    }
 
-	public function get_scripts_by_plugin(): array {
-		global $wp_scripts;
-		$found = [];
-		foreach ( $wp_scripts->registered ?? [] as $handle => $data ) {
-			if ( isset( $data->src ) && strpos( wp_normalize_path( $data->src ), "/{$this->slug}/" ) !== false ) {
-				$found[] = ['handle' => $handle, 'src' => $data->src];
-			}
-		}
+    public function get_scripts_by_plugin(): array
+    {
+        global $wp_scripts;
+        $found = [];
+        foreach ( $wp_scripts->registered ?? [] as $handle => $data ) {
+            if (isset($data->src) && strpos(wp_normalize_path($data->src), "/{$this->slug}/") !== false ) {
+                $found[] = ['handle' => $handle, 'src' => $data->src];
+            }
+        }
 
-		return $found;
-	}
+        return $found;
+    }
 
-	public function get_styles_by_plugin(): array {
-		global $wp_styles;
-		$found = [];
-		foreach ( $wp_styles->registered ?? [] as $handle => $data ) {
-			if ( isset( $data->src ) && strpos( wp_normalize_path( $data->src ), "/{$this->slug}/" ) !== false ) {
-				$found[] = ['handle' => $handle, 'src' => $data->src];
-			}
-		}
+    public function get_styles_by_plugin(): array
+    {
+        global $wp_styles;
+        $found = [];
+        foreach ( $wp_styles->registered ?? [] as $handle => $data ) {
+            if (isset($data->src) && strpos(wp_normalize_path($data->src), "/{$this->slug}/") !== false ) {
+                $found[] = ['handle' => $handle, 'src' => $data->src];
+            }
+        }
 
-		return $found;
-	}
+        return $found;
+    }
 
-	public function get_registered_post_types(): array {
-		$types = [];
-		foreach ( get_post_types( ['_builtin' => false], 'objects' ) as $cpt ) {
-			if ( strpos( $cpt->name, $this->slug ) !== false ||
-				strpos( $cpt->rewrite['slug'] ?? '', $this->slug ) !== false ||
-				strpos( $cpt->rest_base ?? '', $this->slug ) !== false ) {
-				$types[] = $cpt->name;
-			}
-		}
+    public function get_registered_post_types(): array
+    {
+            $types = [];
+            $map   = PostTypeTracker::get_map();
 
-		return $types;
-	}
+        if (! empty($map) ) {
+            foreach ( $map as $slug => $file ) {
+                if (strpos(wp_normalize_path($file), "/{$this->slug}/") !== false ) {
+                      $types[] = $slug;
+                }
+            }
 
-	public function get_cron_jobs_by_plugin(): array {
-		$cron = _get_cron_array();
-		$jobs = [];
-		foreach ( $cron as $hooks ) {
-			foreach ( $hooks as $hook => $events ) {
-				foreach ( $events as $event ) {
-					$file = $this->get_callback_file( $event['function'] ?? '' );
-					if ( $file && $this->belongs_to_plugin( $file ) ) {
-						$jobs[] = [
-							'hook'     => $hook,
-							'schedule' => $event['schedule'] ?? 'single',
-						];
-					}
-				}
-			}
-		}
+               return $types;
+        }
 
-		return $jobs;
-	}
+        foreach ( get_post_types(['_builtin' => false], 'objects') as $cpt ) {
+            if (strpos($cpt->name, $this->slug) !== false 
+                || strpos($cpt->rewrite['slug'] ?? '', $this->slug) !== false 
+                || strpos($cpt->rest_base ?? '', $this->slug) !== false 
+            ) {
+                $types[] = $cpt->name;
+            }
+        }
 
-	public function get_plugin_query_count(): int {
-		global $wpdb;
-		if ( ! defined( 'SAVEQUERIES' ) || ! SAVEQUERIES || empty( $wpdb->queries ) ) {
-			return 0;
-		}
+            return $types;
+    }
 
-		$count = 0;
-		foreach ( $wpdb->queries as $query ) {
-			foreach ( $query[2] ?? [] as $trace ) {
-				if ( isset( $trace['file'] ) && $this->belongs_to_plugin( $trace['file'] ) ) {
-					$count++;
-					break;
-				}
-			}
-		}
+    public function get_cron_jobs_by_plugin(): array
+    {
+        $cron = _get_cron_array();
+        $jobs = [];
+        foreach ( $cron as $hooks ) {
+            foreach ( $hooks as $hook => $events ) {
+                foreach ( $events as $event ) {
+                    $file = $this->get_callback_file($event['function'] ?? '');
+                    if ($file && $this->belongs_to_plugin($file) ) {
+                        $jobs[] = [
+                         'hook'     => $hook,
+                         'schedule' => $event['schedule'] ?? 'single',
+                        ];
+                    }
+                }
+            }
+        }
 
-		return $count;
-	}
+        return $jobs;
+    }
+
+    public function get_plugin_query_count(): int
+    {
+        global $wpdb;
+        if (! defined('SAVEQUERIES') || ! SAVEQUERIES || empty($wpdb->queries) ) {
+            return 0;
+        }
+
+        $count = 0;
+        foreach ( $wpdb->queries as $query ) {
+            foreach ( $query[2] ?? [] as $trace ) {
+                if (isset($trace['file']) && $this->belongs_to_plugin($trace['file']) ) {
+                    $count++;
+                    break;
+                }
+            }
+        }
+
+        return $count;
+    }
 }

--- a/app/Services/PostTypeTracker.php
+++ b/app/Services/PostTypeTracker.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace BoltAudit\App\Services;
+
+defined('ABSPATH') || exit;
+
+class PostTypeTracker
+{
+    protected static array $map = [];
+
+    public static function init(): void
+    {
+        $stored = get_option('boltaudit_post_type_files', []);
+        if (is_array($stored) ) {
+            self::$map = $stored;
+        }
+
+        add_action('registered_post_type', [self::class, 'capture'], 10, 2);
+    }
+
+    public static function capture( string $slug, $args ): void
+    {
+        if (isset(self::$map[ $slug ]) ) {
+            return;
+        }
+
+        $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+        $file      = '';
+        foreach ( $backtrace as $frame ) {
+            if (isset($frame['file']) ) {
+                $file = $frame['file'];
+                if (strpos($file, WP_PLUGIN_DIR) === 0 ) {
+                    break;
+                }
+            }
+        }
+
+        if ($file ) {
+            self::$map[ $slug ] = $file;
+            update_option('boltaudit_post_type_files', self::$map);
+        }
+    }
+
+    public static function get_map(): array
+    {
+        if (empty(self::$map) ) {
+            $stored = get_option('boltaudit_post_type_files', []);
+            if (is_array($stored) ) {
+                self::$map = $stored;
+            }
+        }
+
+        return self::$map;
+    }
+}

--- a/boltaudit.php
+++ b/boltaudit.php
@@ -3,6 +3,7 @@
 defined( 'ABSPATH' ) || exit;
 
 use BoltAudit\WpMVC\App;
+use BoltAudit\App\Services\PostTypeTracker;
 
 /**
  * Plugin Name:       BoltAudit – Performance Audit Advisor
@@ -36,9 +37,11 @@ final class BoltAudit {
 	public function load() {
 		register_activation_hook( __FILE__, [$this, 'on_activation'] );
 
-		$application = App::instance();
+               $application = App::instance();
 
-		$application->boot( __FILE__, __DIR__ );
+               $application->boot( __FILE__, __DIR__ );
+
+               add_action( 'init', [PostTypeTracker::class, 'init'], 0 );
 
 		/**
 		 * Fires once activated plugins have loaded.


### PR DESCRIPTION
## Summary
- track the plugin file that registers each CPT
- initialise tracker on `init`
- consult tracked CPT map when collecting metrics

## Testing
- `composer setup` *(fails: php-scoper error)*
- `vendor-src/bin/phpcs --standard=dev-tools/phpcs.xml app/Services/PostTypeTracker.php` *(fails: coding standard violations)*

------
https://chatgpt.com/codex/tasks/task_e_687cc18a1cd48332be67cfe7a2f0c910