### PR TITLE
Fix cron job collection for invalid arrays

### DIFF
--- a/app/Services/PluginMetricsCollector.php
+++ b/app/Services/PluginMetricsCollector.php
@@ -123,9 +123,12 @@ class PluginMetricsCollector {
 		return $types;
 	}
 
-	public function get_cron_jobs_by_plugin(): array {
-		$cron = _get_cron_array();
-		$jobs = [];
+        public function get_cron_jobs_by_plugin(): array {
+                $cron = _get_cron_array();
+                if ( ! is_array( $cron ) ) {
+                        return [];
+                }
+                $jobs = [];
 		foreach ( $cron as $hooks ) {
 			foreach ( $hooks as $hook => $events ) {
 				foreach ( $events as $event ) {


### PR DESCRIPTION
## Summary
- check for array before processing cron jobs

## Testing
- `vendor-src/bin/phpcs --standard=dev-tools/phpcs.xml app/Services/PluginMetricsCollector.php` *(fails: found 129 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687cc1fa9e608332b493c2a2f409cf2b