### PR TITLE
Handle ReflectionException in get_callback_file

### DIFF
--- a/app/Services/PluginMetricsCollector.php
+++ b/app/Services/PluginMetricsCollector.php
@@ -64,10 +64,14 @@ class PluginMetricsCollector {
 
 				return $ref->getFileName();
 			}
-		} catch ( \ReflectionException $e ) {}
+               } catch ( \ReflectionException $e ) {
+                       error_log( $e->getMessage() );
 
-		return;
-	}
+                       return null;
+               }
+
+               return null;
+       }
 
 	public function get_hooks_by_plugin(): int {
 		global $wp_filter;


### PR DESCRIPTION
## Summary
- log the exception when reflection fails in `get_callback_file`

## Testing
- `vendor-src/bin/phpcs --standard=dev-tools/phpcs.xml`

------
https://chatgpt.com/codex/tasks/task_e_687cc1fc2188833282b1fffc2c9fad66