### PR TITLE
Handle plugins_api failure

### DIFF
--- a/app/Repositories/SinglePluginRepository.php
+++ b/app/Repositories/SinglePluginRepository.php
@@ -106,18 +106,23 @@ class SinglePluginRepository {
 		];
 	}
 
-	protected static function fetch_wp_org_info( string $slug ) {
-		if ( ! function_exists( 'plugins_api' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
-		}
+       protected static function fetch_wp_org_info( string $slug ) {
+               if ( ! function_exists( 'plugins_api' ) ) {
+                       require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
+               }
 
-		$info = plugins_api( 'plugin_information', [
-			'slug'   => $slug,
-			'fields' => ['last_updated' => true],
-		] );
+               try {
+                       $info = plugins_api( 'plugin_information', [
+                               'slug'   => $slug,
+                               'fields' => [ 'last_updated' => true ],
+                       ] );
+               } catch ( \Throwable $e ) {
+                       error_log( sprintf( 'plugins_api failed for %s: %s', $slug, $e->getMessage() ) );
+                       $info = null;
+               }
 
-		return is_wp_error( $info ) ? null : $info;
-	}
+               return is_wp_error( $info ) ? null : $info;
+       }
 
 	protected static function is_abandoned( string $last_updated ): bool {
 		$timestamp = strtotime( $last_updated );


### PR DESCRIPTION
## Summary
- handle cases where plugins_api may throw an exception

## Testing
- `composer install --no-interaction`
- `vendor-src/bin/phpcs --standard=dev-tools/phpcs.xml` *(fails: the "dev-tools/phpcs.xml" coding standard is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68866528cef48332b52c9af1afc7e542