### PR TITLE
Add detailed posts endpoint

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace BoltAudit\App\Http\Controllers;
+
+use BoltAudit\App\Repositories\PostsRepository;
+use BoltAudit\WpMVC\Routing\Response;
+use Exception;
+
+class PostController extends Controller {
+        public function index() {
+                try {
+                        $response = PostsRepository::get_all_details();
+
+                        return Response::send( $response );
+                } catch ( Exception $e ) {
+                        return Response::send(
+                                [
+                                        'message' => $e->getMessage(),
+                                ],
+                                500
+                        );
+                }
+        }
+}

--- a/app/Repositories/PostsRepository.php
+++ b/app/Repositories/PostsRepository.php
@@ -242,16 +242,49 @@ class PostsRepository {
 		return $suggestions;
 	}
 
-	public static function get_all() {
-		return [
-			'total_posts'         => self::get_posts_count(),
-			'post_types'          => self::get_post_type_counts(),
-			'post_types_orphaned' => self::get_orphaned_post_types(),
-			'revisions'           => self::get_post_revisions_count(),
-			'post_meta_total'     => self::get_post_meta_count(),
-			'post_meta_by_type'   => self::get_post_type_meta_counts(),
-			'percentages'         => self::get_percentage_breakdown(),
-			'suggestions'         => self::get_suggestions(),
-		];
-	}
+        public static function get_all() {
+                return [
+                        'total_posts'         => self::get_posts_count(),
+                        'post_types'          => self::get_post_type_counts(),
+                        'post_types_orphaned' => self::get_orphaned_post_types(),
+                        'revisions'           => self::get_post_revisions_count(),
+                        'post_meta_total'     => self::get_post_meta_count(),
+                        'post_meta_by_type'   => self::get_post_type_meta_counts(),
+                        'percentages'         => self::get_percentage_breakdown(),
+                        'suggestions'         => self::get_suggestions(),
+                ];
+        }
+
+        public static function get_all_details() {
+                $post_types = self::get_post_type_counts();
+                $post_meta  = self::get_post_type_meta_counts();
+
+                $registered = [];
+                foreach ( $post_types as $type => $count ) {
+                        if ( '_orphaned_posts' === $type ) {
+                                continue;
+                        }
+
+                        $registered[ $type ] = [
+                                'count' => $count,
+                                'meta'  => $post_meta[ $type ] ?? 0,
+                        ];
+                }
+
+                $orphaned = [];
+                foreach ( self::get_orphaned_post_types() as $type => $count ) {
+                        $orphaned[ $type ] = [
+                                'count' => $count,
+                                'meta'  => $post_meta[ $type ] ?? 0,
+                        ];
+                }
+
+                return [
+                        'total_posts'     => self::get_posts_count(),
+                        'post_meta_total' => self::get_post_meta_count(),
+                        'revisions'       => self::get_post_revisions_count(),
+                        'registered'      => $registered,
+                        'orphaned'        => $orphaned,
+                ];
+        }
 }

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -6,6 +6,7 @@ import { ThemeProvider } from "styled-components";
 
 const HomePage = lazy(() => import("./pages/HomePage"));
 const PluginDetailsPage = lazy(() => import("./pages/PluginDetails"));
+const PostDetailsPage = lazy(() => import("./pages/PostDetails"));
 
 function App() {
   const [dir, setDir] = useState("ltr");
@@ -25,10 +26,14 @@ function App() {
       element: <HomePage />,
     },
 
-		{
-			path: `/plugin/:slug`,
-			element: <PluginDetailsPage />,
-		},
+                {
+                        path: `/plugin/:slug`,
+                        element: <PluginDetailsPage />,
+                },
+    {
+      path: `/posts`,
+      element: <PostDetailsPage />,
+    },
   ]);
 
   const preloaderStyle = {

--- a/resources/js/modules/HomepageContent/PostSection.js
+++ b/resources/js/modules/HomepageContent/PostSection.js
@@ -1,7 +1,11 @@
 import ContentLoading from "@components/ContentLoading";
 import CountUp from "@components/CountUp";
 import postData from "@helper/postData";
+import ReactSVG from "react-inlinesvg";
+import { Link } from "react-router-dom";
 import { useEffect, useState } from "@wordpress/element";
+
+import arrowRightIcon from "@icon/arrow-right.svg";
 
 export default function PostSection() {
   const [dataFetched, setDataFetched] = useState(false);
@@ -36,12 +40,15 @@ export default function PostSection() {
         See how many posts, pages, and custom content types your site has—plus how much metadata is attached.<br/>
         Quickly spot unused or bloated content types that may be slowing things down.
       </p>
-      {/* <a
-        href="#"
-        className="ba-dashboard__content__section__btn ba-dashboard__btn"
+      <Link
+        to="/posts"
+        className="ba-dashboard__content__overview__btn ba-dashboard__btn"
       >
-        Security analytics documentation
-      </a> */}
+        <span className="bs-dashboard-tooltip">
+          Open Detailed Report{" "}
+          <ReactSVG src={arrowRightIcon} width={16} height={16} />
+        </span>
+      </Link>
       <div className="ba-dashboard__content__section__content">
         <div className="ba-dashboard__content__section__overview">
           <div className="ba-dashboard__content__section__overview__single">

--- a/resources/js/modules/PostDetailsContent/index.js
+++ b/resources/js/modules/PostDetailsContent/index.js
@@ -1,0 +1,105 @@
+import ContentLoading from "@components/ContentLoading";
+import CountUp from "@components/CountUp";
+
+export default function PostDetailsModule({ data }) {
+  if (!data) {
+    return <ContentLoading />;
+  }
+
+  const registered = Object.entries(data.registered || {});
+  const orphan = Object.entries(data.orphaned || {});
+
+  return (
+    <>
+      <div className="ba-dashboard__content__section">
+        <h4 className="ba-dashboard__content__section__title">Post Summary</h4>
+        <div className="ba-dashboard__content__section__overview">
+          <div className="ba-dashboard__content__section__overview__single">
+            <span className="ba-dashboard__content__section__overview__title">
+              Post Types
+            </span>
+            <span className="ba-dashboard__content__section__overview__count">
+              <CountUp target={registered.length} />
+            </span>
+          </div>
+          <div className="ba-dashboard__content__section__overview__single">
+            <span className="ba-dashboard__content__section__overview__title">
+              Total Items
+            </span>
+            <span className="ba-dashboard__content__section__overview__count">
+              <CountUp target={data.total_posts} />
+            </span>
+          </div>
+          <div className="ba-dashboard__content__section__overview__single">
+            <span className="ba-dashboard__content__section__overview__title">
+              Total Meta
+            </span>
+            <span className="ba-dashboard__content__section__overview__count">
+              <CountUp target={data.post_meta_total} />
+            </span>
+          </div>
+          <div className="ba-dashboard__content__section__overview__single">
+            <span className="ba-dashboard__content__section__overview__title">
+              Revisions
+            </span>
+            <span className="ba-dashboard__content__section__overview__count">
+              <CountUp target={data.revisions} />
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div className="ba-dashboard__content__section">
+        <h4 className="ba-dashboard__content__section__title">Registered Post Types</h4>
+        <div className="ba-dashboard__content__section__data">
+          <table>
+            <thead>
+              <tr>
+                <th>Post Type</th>
+                <th>Total Items</th>
+                <th>Total Meta</th>
+              </tr>
+            </thead>
+            <tbody>
+              {registered.map(([type, info]) => (
+                <tr key={type}>
+                  <td>{type}</td>
+                  <td>{info.count}</td>
+                  <td>{info.meta}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div className="ba-dashboard__content__section">
+        <h4 className="ba-dashboard__content__section__title">Orphaned Post Types</h4>
+        <div className="ba-dashboard__content__section__data">
+          {orphan.length > 0 ? (
+            <table>
+              <thead>
+                <tr>
+                  <th>Post Type</th>
+                  <th>Total Items</th>
+                  <th>Total Meta</th>
+                </tr>
+              </thead>
+              <tbody>
+                {orphan.map(([type, info]) => (
+                  <tr key={type}>
+                    <td>{type}</td>
+                    <td>{info.count}</td>
+                    <td>{info.meta}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          ) : (
+            <p>No orphan post types detected.</p>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/resources/js/pages/PostDetails.js
+++ b/resources/js/pages/PostDetails.js
@@ -1,0 +1,39 @@
+import postData from "@helper/postData";
+import AppLayout from "@layout/AppLayout";
+import HomepageContentSidebarModule from "@modules/HomepageContentSidebar";
+import PostDetailsModule from "@modules/PostDetailsContent";
+import { useEffect, useState } from "@wordpress/element";
+
+const PostDetailsPage = () => {
+  const [data, setData] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchData() {
+      const res = await postData("boltaudit/posts/details");
+      if (!cancelled) {
+        setData(res);
+      }
+    }
+
+    fetchData();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <AppLayout>
+      <div className="ba-dashboard__content">
+        <div className="ba-dashboard__content__wrapper">
+          <PostDetailsModule data={data} />
+        </div>
+        <HomepageContentSidebarModule />
+      </div>
+    </AppLayout>
+  );
+};
+
+export default PostDetailsPage;

--- a/routes/rest/api.php
+++ b/routes/rest/api.php
@@ -1,8 +1,10 @@
 <?php
 
 use BoltAudit\App\Http\Controllers\PluginController;
+use BoltAudit\App\Http\Controllers\PostController;
 use BoltAudit\App\Http\Controllers\ReportController;
 use BoltAudit\WpMVC\Routing\Route;
 
 Route::post( 'reports/{type}', [ReportController::class, 'index'] );
 Route::post( 'plugin/{slug}', [PluginController::class, 'index'] );
+Route::post( 'posts/details', [PostController::class, 'index'] );


### PR DESCRIPTION
## Summary
- expose dedicated `posts/details` route with controller and repository support
- query new endpoint on Post Details page
- display registered and orphaned post types in matching tables

## Testing
- `npm test` *(fails: Missing script "test")*
- `composer setup` *(fails: Script vendor-src/bin/php-scoper add-prefix ... returned with error code 255)*
- `composer phpcs` *(fails: vendor/vendor-src/bin/phpcs: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689381241d308332b8c7fb8d8d62e765