### PR TITLE
Add percentages to post details and improve layout navigation

### DIFF
--- a/app/Repositories/PostsRepository.php
+++ b/app/Repositories/PostsRepository.php
@@ -255,9 +255,20 @@ class PostsRepository {
                 ];
         }
 
+        /**
+         * Retrieve detailed information for each post type including counts,
+         * metadata and their relative percentages. Results are grouped by
+         * registered and orphaned post types to make it easy to analyse and
+         * clean up content.
+         */
         public static function get_all_details() {
                 $post_types = self::get_post_type_counts();
                 $post_meta  = self::get_post_type_meta_counts();
+
+                // Calculate percentage breakdowns once to avoid repeated work.
+                $percentages      = self::get_percentage_breakdown();
+                $post_type_perc   = $percentages['post_type_percentage'] ?? [];
+                $post_meta_perc   = $percentages['post_meta_percentage'] ?? [];
 
                 $registered = [];
                 foreach ( $post_types as $type => $count ) {
@@ -266,16 +277,20 @@ class PostsRepository {
                         }
 
                         $registered[ $type ] = [
-                                'count' => $count,
-                                'meta'  => $post_meta[ $type ] ?? 0,
+                                'count'           => $count,
+                                'meta'            => $post_meta[ $type ] ?? 0,
+                                'percentage'      => $post_type_perc[ $type ] ?? 0,
+                                'meta_percentage' => $post_meta_perc[ $type ] ?? 0,
                         ];
                 }
 
                 $orphaned = [];
                 foreach ( self::get_orphaned_post_types() as $type => $count ) {
                         $orphaned[ $type ] = [
-                                'count' => $count,
-                                'meta'  => $post_meta[ $type ] ?? 0,
+                                'count'           => $count,
+                                'meta'            => $post_meta[ $type ] ?? 0,
+                                'percentage'      => $post_type_perc[ $type ] ?? 0,
+                                'meta_percentage' => $post_meta_perc[ $type ] ?? 0,
                         ];
                 }
 

--- a/resources/js/layout/AppLayout.js
+++ b/resources/js/layout/AppLayout.js
@@ -2,15 +2,22 @@ import Header from "@layout/Header";
 import Sidebar from "@layout/Sidebar";
 import { useParams } from "react-router-dom";
 
-const AppLayout = ({ children }) => {
+// Generic application layout used across all pages. The layout can be
+// customized via the optional `type` and `page` props allowing details pages
+// (such as plugins or posts) to reuse the same structure while updating the
+// header and sidebar navigation.
+const AppLayout = ({ children, type: forcedType, page: forcedPage }) => {
   const { slug } = useParams();
-  const type = slug ? "detailsHeader" : null;
+  // When a slug exists (e.g., plugin detail pages), show the details header by
+  // default. For other pages the type/page can be explicitly provided.
+  const type = forcedType || (slug ? "detailsHeader" : null);
+  const page = forcedPage || (slug ? "pluginDetails" : null);
 
   return (
     <div className="ba-dashboard">
       <Header type={type} />
       <div className="ba-dashboard__wrapper">
-        <Sidebar type={type} />
+        <Sidebar type={type} page={page} />
         {children}
       </div>
     </div>

--- a/resources/js/layout/Sidebar/index.js
+++ b/resources/js/layout/Sidebar/index.js
@@ -6,14 +6,31 @@ const Sidebar = (props) => {
   const [activeSection, setActiveSection] = useState("");
   const [isSidebarFixed, setIsSidebarFixed] = useState(false);
 
-  const type = props.type;
+  const { page } = props;
 
+  // Determine which sections to display based on the current page. This keeps
+  // the navigation focused and relevant.
   const sections =
-    type === "detailsHeader"
+    page === "pluginDetails"
       ? [
           {
             id: "ba-dashboard__styles_scripts",
             name: "Assets",
+          },
+        ]
+      : page === "postDetails"
+      ? [
+          {
+            id: "ba-dashboard__post_summary",
+            name: "Post Summary",
+          },
+          {
+            id: "ba-dashboard__registered_post_types",
+            name: "Registered",
+          },
+          {
+            id: "ba-dashboard__orphan_post_types",
+            name: "Orphaned",
           },
         ]
       : [
@@ -37,7 +54,7 @@ const Sidebar = (props) => {
                 },
               ]
             : []),
-                      {
+          {
             id: "ba-dashboard__environment",
             name: "Environment",
           },

--- a/resources/js/modules/PostDetailsContent/index.js
+++ b/resources/js/modules/PostDetailsContent/index.js
@@ -11,8 +11,15 @@ export default function PostDetailsModule({ data }) {
 
   return (
     <>
-      <div className="ba-dashboard__content__section">
+      <div
+        id="ba-dashboard__post_summary"
+        className="ba-dashboard__content__section"
+      >
         <h4 className="ba-dashboard__content__section__title">Post Summary</h4>
+        <p className="ba-dashboard__content__section__desc">
+          A quick overview of your site's content footprint including total
+          posts, metadata and revisions.
+        </p>
         <div className="ba-dashboard__content__section__overview">
           <div className="ba-dashboard__content__section__overview__single">
             <span className="ba-dashboard__content__section__overview__title">
@@ -49,8 +56,17 @@ export default function PostDetailsModule({ data }) {
         </div>
       </div>
 
-      <div className="ba-dashboard__content__section">
-        <h4 className="ba-dashboard__content__section__title">Registered Post Types</h4>
+      <div
+        id="ba-dashboard__registered_post_types"
+        className="ba-dashboard__content__section"
+      >
+        <h4 className="ba-dashboard__content__section__title">
+          Registered Post Types
+        </h4>
+        <p className="ba-dashboard__content__section__desc">
+          Breakdown of all post types currently registered on your site and
+          their associated metadata.
+        </p>
         <div className="ba-dashboard__content__section__data">
           <table>
             <thead>
@@ -64,8 +80,28 @@ export default function PostDetailsModule({ data }) {
               {registered.map(([type, info]) => (
                 <tr key={type}>
                   <td>{type}</td>
-                  <td>{info.count}</td>
-                  <td>{info.meta}</td>
+                  <td>
+                    <span className="data-wrapper">
+                      <span className="data-count">{info.count}</span>
+                      <span className="data-progress-wrapper">
+                        <span
+                          className="data-progress"
+                          style={{ width: `${info.percentage}%` }}
+                        ></span>
+                      </span>
+                    </span>
+                  </td>
+                  <td>
+                    <span className="data-wrapper">
+                      <span className="data-count">{info.meta}</span>
+                      <span className="data-progress-wrapper">
+                        <span
+                          className="data-progress"
+                          style={{ width: `${info.meta_percentage}%` }}
+                        ></span>
+                      </span>
+                    </span>
+                  </td>
                 </tr>
               ))}
             </tbody>
@@ -73,8 +109,17 @@ export default function PostDetailsModule({ data }) {
         </div>
       </div>
 
-      <div className="ba-dashboard__content__section">
-        <h4 className="ba-dashboard__content__section__title">Orphaned Post Types</h4>
+      <div
+        id="ba-dashboard__orphan_post_types"
+        className="ba-dashboard__content__section"
+      >
+        <h4 className="ba-dashboard__content__section__title">
+          Orphaned Post Types
+        </h4>
+        <p className="ba-dashboard__content__section__desc">
+          Unregistered post types that still exist in the database. Review and
+          clean up if necessary.
+        </p>
         <div className="ba-dashboard__content__section__data">
           {orphan.length > 0 ? (
             <table>
@@ -89,8 +134,28 @@ export default function PostDetailsModule({ data }) {
                 {orphan.map(([type, info]) => (
                   <tr key={type}>
                     <td>{type}</td>
-                    <td>{info.count}</td>
-                    <td>{info.meta}</td>
+                    <td>
+                      <span className="data-wrapper">
+                        <span className="data-count">{info.count}</span>
+                        <span className="data-progress-wrapper">
+                          <span
+                            className="data-progress"
+                            style={{ width: `${info.percentage}%` }}
+                          ></span>
+                        </span>
+                      </span>
+                    </td>
+                    <td>
+                      <span className="data-wrapper">
+                        <span className="data-count">{info.meta}</span>
+                        <span className="data-progress-wrapper">
+                          <span
+                            className="data-progress"
+                            style={{ width: `${info.meta_percentage}%` }}
+                          ></span>
+                        </span>
+                      </span>
+                    </td>
                   </tr>
                 ))}
               </tbody>

--- a/resources/js/pages/PostDetails.js
+++ b/resources/js/pages/PostDetails.js
@@ -25,7 +25,7 @@ const PostDetailsPage = () => {
   }, []);
 
   return (
-    <AppLayout>
+    <AppLayout type="detailsHeader" page="postDetails">
       <div className="ba-dashboard__content">
         <div className="ba-dashboard__content__wrapper">
           <PostDetailsModule data={data} />


### PR DESCRIPTION
## Summary
- expose per-type post and meta percentages in `get_all_details`
- enhance post details page with descriptions and progress bars
- update layout sidebar/header to support post detail navigation

## Testing
- `npm test` *(fails: Missing script "test")*
- `php -l app/Repositories/PostsRepository.php`


------
https://chatgpt.com/codex/tasks/task_e_68949c322e9483328e08590aca0dc33d