### PR TITLE
Display orphan post and meta totals in post details

### DIFF
--- a/app/Repositories/PostsRepository.php
+++ b/app/Repositories/PostsRepository.php
@@ -186,22 +186,29 @@ class PostsRepository {
 			];
 		}
 
-		$orphaned = [];
-		foreach ( self::get_orphaned_post_types() as $type => $count ) {
-			$orphaned[$type] = [
-				'count'           => $count,
-				'meta'            => $post_meta[$type] ?? 0,
-				'percentage'      => $post_type_percentage[$type] ?? 0,
-				'meta_percentage' => $post_meta_percentage[$type] ?? 0,
-			];
-		}
+               $orphaned           = [];
+               $orphan_post_total  = 0;
+               $orphan_meta_total  = 0;
+               foreach ( self::get_orphaned_post_types() as $type => $count ) {
+                       $meta_count          = $post_meta[$type] ?? 0;
+                       $orphan_post_total  += $count;
+                       $orphan_meta_total  += $meta_count;
+                       $orphaned[$type]     = [
+                               'count'           => $count,
+                               'meta'            => $meta_count,
+                               'percentage'      => $post_type_percentage[$type] ?? 0,
+                               'meta_percentage' => $post_meta_percentage[$type] ?? 0,
+                       ];
+               }
 
-		return [
-			'total_posts'     => self::get_posts_count(),
-			'post_meta_total' => self::get_meta_count(),
-			'revisions'       => self::get_revisions_count(),
-			'registered'      => $registered,
-			'orphaned'        => $orphaned,
-		];
+               return [
+                       'total_posts'        => self::get_posts_count(),
+                       'post_meta_total'    => self::get_meta_count(),
+                       'revisions'          => self::get_revisions_count(),
+                       'registered'         => $registered,
+                       'orphaned'           => $orphaned,
+                       'orphan_posts_total' => $orphan_post_total,
+                       'orphan_meta_total'  => $orphan_meta_total,
+               ];
 	}
 }

--- a/resources/js/modules/PostDetailsContent/index.js
+++ b/resources/js/modules/PostDetailsContent/index.js
@@ -53,6 +53,22 @@ export default function PostDetailsModule({ data }) {
               <CountUp target={data.revisions} />
             </span>
           </div>
+          <div className="ba-dashboard__content__section__overview__single">
+            <span className="ba-dashboard__content__section__overview__title">
+              Orphaned Posts
+            </span>
+            <span className="ba-dashboard__content__section__overview__count">
+              <CountUp target={data.orphan_posts_total} />
+            </span>
+          </div>
+          <div className="ba-dashboard__content__section__overview__single">
+            <span className="ba-dashboard__content__section__overview__title">
+              Orphaned Meta
+            </span>
+            <span className="ba-dashboard__content__section__overview__count">
+              <CountUp target={data.orphan_meta_total} />
+            </span>
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- compute and return total orphan post and meta counts
- show orphaned post and meta totals in post details summary

## Testing
- `composer format` (fails: vendor/vendor-src/bin/phpcbf: not found)
- `composer phpcs` (fails: vendor/vendor-src/bin/phpcs: not found)
- `npm test` (fails: Missing script: "test")


------
https://chatgpt.com/codex/tasks/task_e_6895c6bcf4ac8332bc3790aedf9def92