### PR TITLE
feat: apply WordPress coding standards

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -39,4 +39,4 @@ jobs:
         run: composer setup
 
       - name: Run PHPCS checks
-        run: php vendor/vendor-src/bin/phpcs --standard=phpcs.xml
+        run: composer phpcs

--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,13 @@
 			"vendor-src/bin/php-scoper add-prefix --config=dev-tools/scoper/index.php --output-dir vendor --force",
 			"composer dump-autoload -d vendor"
 		],
-		"format": "vendor/vendor-src/bin/phpcbf --standard=dev-tools/phpcs.xml",
-		"phpcs": "vendor/vendor-src/bin/phpcs --standard=dev-tools/phpcs.xml",
-		"permission": [
-			"chmod +x vendor/vendor-src/bin/phpcs",
-			"chmod +x vendor/vendor-src/bin/phpcbf"
-		]
+                "phpcbf": "vendor-src/bin/phpcbf --standard=phpcs.xml .",
+                "phpcs": "vendor-src/bin/phpcs --standard=phpcs.xml .",
+                "format": "@phpcbf",
+                "permission": [
+                        "chmod +x vendor-src/bin/phpcs",
+                        "chmod +x vendor-src/bin/phpcbf"
+                ]
 	},
 	"autoload": {
 		"psr-4": {

--- a/config/app.php
+++ b/config/app.php
@@ -1,108 +1,110 @@
 <?php
+/**
+ * BoltAudit configuration.
+ *
+ * @package BoltAudit
+ */
 
 defined( 'ABSPATH' ) || exit;
 
 use BoltAudit\App\Http\Middleware\EnsureIsUserAdmin;
 use BoltAudit\App\Providers\MenuServiceProvider;
-// use BoltAudit\Database\Migrations\TestMigration;
 use BoltAudit\WpMVC\Helpers\Helpers;
 
-return [
-    /**
-     * The version of the plugin.
-     */
-    'version'                     => Helpers::get_plugin_version( 'boltaudit' ),
+return array(
+	/**
+	 * The version of the plugin.
+	 */
+	'version'                     => Helpers::get_plugin_version( 'boltaudit' ),
 
-    /**
-     * Configuration for the REST API.
-     */
-    'rest_api'                    => [
-        /**
-         * The namespace for the REST API.
-         */
-        'namespace' => 'boltaudit',
-        
-        /**
-         * The versions of the REST API.
-         */
-        'versions'  => []
-    ],
+	/**
+	 * Configuration for the REST API.
+	 */
+	'rest_api'                    => array(
+		/**
+		 * The namespace for the REST API.
+		 */
+		'namespace' => 'boltaudit',
 
-    /**
-     * Configuration for the AJAX API.
-     */
-    'ajax_api'                    => [
-        /**
-         * The namespace for the AJAX API.
-         */
-        'namespace' => 'boltaudit',
-        
-        /**
-         * The versions of the AJAX API.
-         */
-        'versions'  => []
-    ],
+		/**
+		 * The versions of the REST API.
+		 */
+		'versions'  => array(),
+	),
 
-    /**
-     * Service providers for the plugin.
-     */
-    'providers'                   => [],
+	/**
+	 * Configuration for the AJAX API.
+	 */
+	'ajax_api'                    => array(
+		/**
+		 * The namespace for the AJAX API.
+		 */
+		'namespace' => 'boltaudit',
 
-    /**
-     * Service providers for the admin area of the plugin.
-     */
-    'admin_providers'             => [
-        MenuServiceProvider::class,
-    ],
+		/**
+		 * The versions of the AJAX API.
+		 */
+		'versions'  => array(),
+	),
 
-    /**
-     * Middleware configuration for the plugin.
-     */
-    'middleware'                  => [
-        /**
-         * Middleware for admin routes.
-         */
-        'admin' => EnsureIsUserAdmin::class
-    ],
+	/**
+	 * Service providers for the plugin.
+	 */
+	'providers'                   => array(),
 
-    /**
-     * The database option key for storing migration information.
-     */
-    // 'migration_db_option_key'     => 'boltaudit_migrations',
+	/**
+	 * Service providers for the admin area of the plugin.
+	 */
+	'admin_providers'             => array(
+		MenuServiceProvider::class,
+	),
 
-    /**
-     * List of migrations for the plugin.
-     */
-    'migrations'                  => [
-        // 'test-migration' => TestMigration::class,
-    ],
+	/**
+	 * Middleware configuration for the plugin.
+	 */
+	'middleware'                  => array(
+		/**
+		 * Middleware for admin routes.
+		 */
+		'admin' => EnsureIsUserAdmin::class,
+	),
 
-    /**
-     * This configuration option defines a hook that will fire before executing the route callback,
-     * such as before a controller action. It provides two parameters:
-     * 
-     * @param WP_REST_Request $wp_rest_request The current REST request object.
-     * @param string $full_route The full route being accessed.
-     */
-    'rest_response_action_hook'   => 'boltaudit_rest_response_action',
+	/**
+	 * The database option key for storing migration information.
+	 */
+	// 'migration_db_option_key'     => 'boltaudit_migrations',
 
-    /**
-     * Configuration for the REST API response filter hook.
-     *
-     * This filter hook allows overriding the entire REST API response.
-     * 
-     * @param $response The response object from the controller.
-     * @param WP_REST_Request  $wp_rest_request The request object.
-     * @param string           $full_route The full route of the request.
-     */
-    'rest_response_filter_hook'   => 'boltaudit_rest_response_filter',
+	/**
+	 * List of migrations for the plugin.
+	 */
+	'migrations'                  => array(),
 
-    /**
-     * This filter hook that can override all REST API permissions.
-     * 
-     * @param mixed $permission The current permission setting.
-     * @param mixed $middleware The middleware being applied.
-     * @param string $full_route The full route of the API endpoint.
-     */
-    'rest_permission_filter_hook' => 'boltaudit_rest_permission_filter',
-];
+	/**
+	 * This configuration option defines a hook that will fire before executing the route callback,
+	 * such as before a controller action. It provides two parameters:
+	 *
+	 * @param WP_REST_Request $wp_rest_request The current REST request object.
+	 * @param string $full_route The full route being accessed.
+	 */
+	'rest_response_action_hook'   => 'boltaudit_rest_response_action',
+
+	/**
+	 * Configuration for the REST API response filter hook.
+	 *
+	 * This filter hook allows overriding the entire REST API response.
+	 *
+	 * @param $response The response object from the controller.
+	 * @param WP_REST_Request  $wp_rest_request The request object.
+	 * @param string           $full_route The full route of the request.
+	 */
+	'rest_response_filter_hook'   => 'boltaudit_rest_response_filter',
+
+	/**
+	 * This filter hook that can override all REST API permissions.
+	 *
+	 * @param mixed $permission The current permission setting.
+	 * @param mixed $middleware The middleware being applied.
+	 * @param string $full_route The full route of the API endpoint.
+	 */
+	'rest_permission_filter_hook' => 'boltaudit_rest_permission_filter',
+);

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<ruleset name="BoltAudit">
+    <description>PHPCS ruleset for BoltAudit using WordPress Coding Standards.</description>
+    <config name="minimum_supported_wp_version" value="5.0" />
+    <arg name="extensions" value="php" />
+    <rule ref="WordPress-Core">
+        <exclude name="WordPress.NamingConventions.PrefixAllGlobals" />
+        <exclude name="WordPress.WP.I18n" />
+    </rule>
+    <rule ref="WordPress-Docs" />
+    <rule ref="WordPress-Extra" />
+    <exclude-pattern>vendor/*</exclude-pattern>
+    <exclude-pattern>vendor-src/*</exclude-pattern>
+    <exclude-pattern>node_modules/*</exclude-pattern>
+    <exclude-pattern>assets/*</exclude-pattern>
+    <exclude-pattern>__build/*</exclude-pattern>
+</ruleset>


### PR DESCRIPTION
## Summary
- add WordPress ruleset configuration and exclude vendor directories
- expose composer scripts for `phpcbf` and `phpcs`
- run PHPCS via composer in pull request workflow
- document plugin config and remove commented code

## Testing
- `vendor-src/bin/phpcbf --standard=phpcs.xml config/app.php`
- `vendor-src/bin/phpcs --standard=phpcs.xml config/app.php` *(fails: WordPressCS\WordPress\PHPCSHelper::ignore_annotations(): Implicitly marking parameter $phpcsFile as nullable is deprecated, the explicit nullable type must be used instead)*

------
https://chatgpt.com/codex/tasks/task_e_6895d0d2097c83328471700b7ec7e286