### PR TITLE
Handle null script/style arrays in PluginMetricsCollector

### DIFF
--- a/app/Services/PluginMetricsCollector.php
+++ b/app/Services/PluginMetricsCollector.php
@@ -19,17 +19,17 @@ class PluginMetricsCollector {
 
 	protected function collect_now(): array {
 		$scripts = $this->merge_registered_and_enqueued(
-			$this->get_scripts_by_plugin(),
-			$this->get_enqueued_scripts_by_plugin()
+			$this->get_scripts_by_plugin() ?? [],
+			$this->get_enqueued_scripts_by_plugin() ?? []
 		);
 
 		$styles = $this->merge_registered_and_enqueued(
-			$this->get_styles_by_plugin(),
-			$this->get_enqueued_styles_by_plugin()
+			$this->get_styles_by_plugin() ?? [],
+			$this->get_enqueued_styles_by_plugin() ?? []
 		);
 
 		$enqueued = array_filter(
-			array_merge( $scripts, $styles ),
+			array_merge( $scripts ?? [], $styles ?? [] ),
 			fn( $asset ) => ! empty( $asset['enqueued'] )
 		);
 


### PR DESCRIPTION
## Summary
- Avoid passing null to array_merge by coalescing scripts and styles to empty arrays
- Coalesce get_* results before merging registered and enqueued assets

## Testing
- `php -l app/Services/PluginMetricsCollector.php`
- `vendor-src/bin/phpcs --standard=phpcs.xml app/Services/PluginMetricsCollector.php` *(fails: Implicitly marking parameter $phpcsFile as nullable is deprecated)*

------
https://chatgpt.com/codex/tasks/task_e_6895e73a274483329a6cbb14a002a969