### PR TITLE
feat: add database details page

### DIFF
--- a/app/Http/Controllers/DatabaseController.php
+++ b/app/Http/Controllers/DatabaseController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace BoltAudit\App\Http\Controllers;
+
+use BoltAudit\App\Repositories\DatabaseRepository;
+use BoltAudit\WpMVC\Routing\Response;
+use Exception;
+
+class DatabaseController extends Controller {
+        public function index() {
+                try {
+                        $response = DatabaseRepository::get_all();
+
+                        return Response::send( $response );
+                } catch ( Exception $e ) {
+                        return Response::send(
+                                [
+                                        'message' => $e->getMessage(),
+                                ],
+                                500
+                        );
+                }
+        }
+}

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -7,6 +7,7 @@ import { ThemeProvider } from "styled-components";
 const HomePage = lazy(() => import("./pages/HomePage"));
 const PluginDetailsPage = lazy(() => import("./pages/PluginDetails"));
 const PostDetailsPage = lazy(() => import("./pages/PostDetails"));
+const DatabaseDetailsPage = lazy(() => import("./pages/DatabaseDetails"));
 
 function App() {
   const [dir, setDir] = useState("ltr");
@@ -32,6 +33,10 @@ function App() {
     {
       path: `/posts`,
       element: <PostDetailsPage />,
+    },
+    {
+      path: `/database`,
+      element: <DatabaseDetailsPage />,
     },
   ]);
 

--- a/resources/js/layout/Sidebar/index.js
+++ b/resources/js/layout/Sidebar/index.js
@@ -33,6 +33,29 @@ const Sidebar = (props) => {
             name: "Orphaned",
           },
         ]
+      : page === "databaseDetails"
+      ? [
+          {
+            id: "ba-dashboard__database_summary",
+            name: "Summary",
+          },
+          {
+            id: "ba-dashboard__database_tables",
+            name: "Tables",
+          },
+          {
+            id: "ba-dashboard__database_empty_tables",
+            name: "Empty",
+          },
+          {
+            id: "ba-dashboard__database_autoloaded_options",
+            name: "Autoloaded",
+          },
+          {
+            id: "ba-dashboard__database_index_efficiency",
+            name: "Index",
+          },
+        ]
       : [
           {
             id: "ba-dashboard__post",

--- a/resources/js/modules/DatabaseDetailsContent/index.js
+++ b/resources/js/modules/DatabaseDetailsContent/index.js
@@ -1,0 +1,223 @@
+import ContentLoading from "@components/ContentLoading";
+import CountUp from "@components/CountUp";
+
+export default function DatabaseDetailsModule({ data }) {
+  if (!data) {
+    return <ContentLoading />;
+  }
+
+  const tables = [...(data.tables || [])].sort(
+    (a, b) => b.total_size - a.total_size
+  );
+  const emptyTables = data.empty_tables || [];
+  const heavyOptions = data.heavy_autoloaded || [];
+  const indexStats = data.index_efficiency || [];
+
+  return (
+    <>
+      <div
+        id="ba-dashboard__database_summary"
+        className="ba-dashboard__content__section"
+      >
+        <h4 className="ba-dashboard__content__section__title">
+          Database Summary
+        </h4>
+        <p className="ba-dashboard__content__section__desc">
+          Detailed overview of your database size, tables and option usage.
+        </p>
+        <div className="ba-dashboard__content__section__overview">
+          <div className="ba-dashboard__content__section__overview__single">
+            <span className="ba-dashboard__content__section__overview__title">
+              DB Size
+            </span>
+            <span className="ba-dashboard__content__section__overview__count">
+              {data.db_size}
+            </span>
+          </div>
+          <div className="ba-dashboard__content__section__overview__single">
+            <span className="ba-dashboard__content__section__overview__title">
+              Tables
+            </span>
+            <span className="ba-dashboard__content__section__overview__count">
+              <CountUp target={data.total_tables} />
+            </span>
+          </div>
+          <div className="ba-dashboard__content__section__overview__single">
+            <span className="ba-dashboard__content__section__overview__title">
+              Empty Tables
+            </span>
+            <span className="ba-dashboard__content__section__overview__count">
+              <CountUp target={data.total_empty_tables} />
+            </span>
+          </div>
+          <div className="ba-dashboard__content__section__overview__single">
+            <span className="ba-dashboard__content__section__overview__title">
+              Options
+            </span>
+            <span className="ba-dashboard__content__section__overview__count">
+              <CountUp target={data.options.total_options} />
+            </span>
+          </div>
+          <div className="ba-dashboard__content__section__overview__single">
+            <span className="ba-dashboard__content__section__overview__title">
+              Transients
+            </span>
+            <span className="ba-dashboard__content__section__overview__count">
+              <CountUp target={data.options.total_transient} />
+            </span>
+          </div>
+          <div className="ba-dashboard__content__section__overview__single">
+            <span className="ba-dashboard__content__section__overview__title">
+              Autoloaded Options
+            </span>
+            <span className="ba-dashboard__content__section__overview__count">
+              <CountUp target={data.options.total_autoloaded_options} />
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div
+        id="ba-dashboard__database_tables"
+        className="ba-dashboard__content__section"
+      >
+        <h4 className="ba-dashboard__content__section__title">
+          Tables by Size
+        </h4>
+        <p className="ba-dashboard__content__section__desc">
+          All database tables sorted from largest to smallest.
+        </p>
+        <div className="ba-dashboard__content__section__data">
+          <table>
+            <thead>
+              <tr>
+                <th>Table Name</th>
+                <th>Rows</th>
+                <th>Data Size</th>
+                <th>Index Size</th>
+                <th>Total Size</th>
+              </tr>
+            </thead>
+            <tbody>
+              {tables.map((table) => (
+                <tr key={table.table_name}>
+                  <td>{table.table_name}</td>
+                  <td>{table.row_count}</td>
+                  <td>{table.data_size_formatted}</td>
+                  <td>{table.index_size_formatted}</td>
+                  <td>{table.total_size_formatted}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div
+        id="ba-dashboard__database_empty_tables"
+        className="ba-dashboard__content__section"
+      >
+        <h4 className="ba-dashboard__content__section__title">
+          Empty Tables
+        </h4>
+        <p className="ba-dashboard__content__section__desc">
+          Tables detected with zero rows.
+        </p>
+        <div className="ba-dashboard__content__section__data">
+          {emptyTables.length > 0 ? (
+            <table>
+              <thead>
+                <tr>
+                  <th>Table Name</th>
+                  <th>Engine</th>
+                </tr>
+              </thead>
+              <tbody>
+                {emptyTables.map((table) => (
+                  <tr key={table.table_name}>
+                    <td>{table.table_name}</td>
+                    <td>{table.ENGINE || ""}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          ) : (
+            <p>No empty tables found.</p>
+          )}
+        </div>
+      </div>
+
+      <div
+        id="ba-dashboard__database_autoloaded_options"
+        className="ba-dashboard__content__section"
+      >
+        <h4 className="ba-dashboard__content__section__title">
+          Largest Autoloaded Options
+        </h4>
+        <p className="ba-dashboard__content__section__desc">
+          Options loaded on every request ordered by size.
+        </p>
+        <div className="ba-dashboard__content__section__data">
+          {heavyOptions.length > 0 ? (
+            <table>
+              <thead>
+                <tr>
+                  <th>Option Name</th>
+                  <th>Size (bytes)</th>
+                </tr>
+              </thead>
+              <tbody>
+                {heavyOptions.map((opt) => (
+                  <tr key={opt.option_name}>
+                    <td>{opt.option_name}</td>
+                    <td>{opt.size}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          ) : (
+            <p>No autoloaded options detected.</p>
+          )}
+        </div>
+      </div>
+
+      <div
+        id="ba-dashboard__database_index_efficiency"
+        className="ba-dashboard__content__section"
+      >
+        <h4 className="ba-dashboard__content__section__title">
+          Index Efficiency
+        </h4>
+        <p className="ba-dashboard__content__section__desc">
+          Tables with the highest index to data ratio.
+        </p>
+        <div className="ba-dashboard__content__section__data">
+          {indexStats.length > 0 ? (
+            <table>
+              <thead>
+                <tr>
+                  <th>Table</th>
+                  <th>Data Size</th>
+                  <th>Index Size</th>
+                  <th>Index %</th>
+                </tr>
+              </thead>
+              <tbody>
+                {indexStats.map((stat) => (
+                  <tr key={stat.table}>
+                    <td>{stat.table}</td>
+                    <td>{stat.data_size}</td>
+                    <td>{stat.index_size}</td>
+                    <td>{stat.index_ratio}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          ) : (
+            <p>No index statistics available.</p>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/resources/js/modules/HomepageContent/DatabaseSection.js
+++ b/resources/js/modules/HomepageContent/DatabaseSection.js
@@ -1,7 +1,10 @@
 import ContentLoading from "@components/ContentLoading";
 import CountUp from "@components/CountUp";
 import postData from "@helper/postData";
+import ReactSVG from "react-inlinesvg";
+import { Link } from "react-router-dom";
 import { useEffect, useState } from "@wordpress/element";
+import arrowRightIcon from "@icon/arrow-right.svg";
 
 export default function DatabaseSection() {
   const [dataFetched, setDataFetched] = useState(false);
@@ -41,12 +44,15 @@ export default function DatabaseSection() {
         Easily find old data, unused tables, or options that might be making
         your site slower.
       </p>
-      {/* <a
-        href="#"
-        className="ba-dashboard__content__section__btn ba-dashboard__btn"
+      <Link
+        to="/database"
+        className="ba-dashboard__content__overview__btn ba-dashboard__btn"
       >
-        Security analytics documentation
-      </a> */}
+        <span className="bs-dashboard-tooltip">
+          Open Detailed Report {" "}
+          <ReactSVG src={arrowRightIcon} width={16} height={16} />
+        </span>
+      </Link>
       <div className="ba-dashboard__content__section__content">
         {dataFetched ? (
           <div className="ba-dashboard__content__section__overview">
@@ -70,15 +76,6 @@ export default function DatabaseSection() {
 
             <div className="ba-dashboard__content__section__overview__single">
               <span className="ba-dashboard__content__section__overview__title">
-                Empty Tables
-              </span>
-              <span className="ba-dashboard__content__section__overview__count">
-                <CountUp target={allData.total_empty_tables} />
-              </span>
-            </div>
-
-            <div className="ba-dashboard__content__section__overview__single">
-              <span className="ba-dashboard__content__section__overview__title">
                 Options
               </span>
               <span className="ba-dashboard__content__section__overview__count">
@@ -92,15 +89,6 @@ export default function DatabaseSection() {
               </span>
               <span className="ba-dashboard__content__section__overview__count">
                 <CountUp target={allData.options.total_transient} />
-              </span>
-            </div>
-
-            <div className="ba-dashboard__content__section__overview__single">
-              <span className="ba-dashboard__content__section__overview__title">
-                Autoloaded Options
-              </span>
-              <span className="ba-dashboard__content__section__overview__count">
-                <CountUp target={allData.options.total_autoloaded_options} />
               </span>
             </div>
           </div>

--- a/resources/js/pages/DatabaseDetails.js
+++ b/resources/js/pages/DatabaseDetails.js
@@ -1,0 +1,39 @@
+import postData from "@helper/postData";
+import AppLayout from "@layout/AppLayout";
+import HomepageContentSidebarModule from "@modules/HomepageContentSidebar";
+import DatabaseDetailsModule from "@modules/DatabaseDetailsContent";
+import { useEffect, useState } from "@wordpress/element";
+
+const DatabaseDetailsPage = () => {
+  const [data, setData] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchData() {
+      const res = await postData("boltaudit/database/details");
+      if (!cancelled) {
+        setData(res);
+      }
+    }
+
+    fetchData();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <AppLayout type="detailsHeader" page="databaseDetails">
+      <div className="ba-dashboard__content">
+        <div className="ba-dashboard__content__wrapper">
+          <DatabaseDetailsModule data={data} />
+        </div>
+        <HomepageContentSidebarModule />
+      </div>
+    </AppLayout>
+  );
+};
+
+export default DatabaseDetailsPage;

--- a/routes/rest/api.php
+++ b/routes/rest/api.php
@@ -3,8 +3,10 @@
 use BoltAudit\App\Http\Controllers\PluginController;
 use BoltAudit\App\Http\Controllers\PostController;
 use BoltAudit\App\Http\Controllers\ReportController;
+use BoltAudit\App\Http\Controllers\DatabaseController;
 use BoltAudit\WpMVC\Routing\Route;
 
 Route::post( 'reports/{type}', [ReportController::class, 'index'], ['admin'] );
 Route::post( 'plugin/{slug}', [PluginController::class, 'index'], ['admin'] );
 Route::post( 'posts/details', [PostController::class, 'index'], ['admin'] );
+Route::post( 'database/details', [DatabaseController::class, 'index'], ['admin'] );


### PR DESCRIPTION
## Summary
- add route and controller for database details
- create database details page and sidebar navigation
- streamline database overview metrics and link to details

## Testing
- `npm test` *(fails: Missing script: "test")*
- `composer test` *(fails: Command "test" is not defined.)*
- `composer phpcs` *(fails: vendor-src/bin/phpcs: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689881ff87b883329263edbcae7f411c