### PR TITLE
Add WooCommerce detailed report page with performance insights

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,100 +1,107 @@
-import Preloader from "@components/Preloader";
-import { createRoot, lazy, Suspense, useState } from "@wordpress/element";
-import { applyFilters } from "@wordpress/hooks";
-import { HashRouter, Route, Routes } from "react-router-dom";
-import { ThemeProvider } from "styled-components";
+import Preloader from '@components/Preloader';
+import { createRoot, lazy, Suspense, useState } from '@wordpress/element';
+import { applyFilters } from '@wordpress/hooks';
+import { HashRouter, Route, Routes } from 'react-router-dom';
+import { ThemeProvider } from 'styled-components';
 
-const HomePage = lazy(() => import("./pages/HomePage"));
-const PluginDetailsPage = lazy(() => import("./pages/PluginDetails"));
-const PostDetailsPage = lazy(() => import("./pages/PostDetails"));
+const HomePage = lazy( () => import( './pages/HomePage' ) );
+const PluginDetailsPage = lazy( () => import( './pages/PluginDetails' ) );
+const PostDetailsPage = lazy( () => import( './pages/PostDetails' ) );
+const WooCommerceDetailsPage = lazy( () =>
+	import( './pages/WooCommerceDetails' )
+);
 
 function App() {
-  const [dir, setDir] = useState("ltr");
-  const [dataFetched, setDataFetched] = useState(false);
+	const [ dir, setDir ] = useState( 'ltr' );
+	const [ dataFetched, setDataFetched ] = useState( false );
 
-  const theme = {
-    direction: dir,
-  };
+	const theme = {
+		direction: dir,
+	};
 
-  setTimeout(() => {
-    setDataFetched(true);
-  }, 3000);
+	setTimeout( () => {
+		setDataFetched( true );
+	}, 3000 );
 
-  const adminRoutes = applyFilters("ba_dashboard_routes", [
-    {
-      path: `/*`,
-      element: <HomePage />,
-    },
-    {
-      path: `/plugin/:slug`,
-      element: <PluginDetailsPage />,
-    },
-    {
-      path: `/posts`,
-      element: <PostDetailsPage />,
-    },
-  ]);
+	const adminRoutes = applyFilters( 'ba_dashboard_routes', [
+		{
+			path: `/*`,
+			element: <HomePage />,
+		},
+		{
+			path: `/plugin/:slug`,
+			element: <PluginDetailsPage />,
+		},
+		{
+			path: `/posts`,
+			element: <PostDetailsPage />,
+		},
+		{
+			path: `/woocommerce`,
+			element: <WooCommerceDetailsPage />,
+		},
+	] );
 
-  const preloaderStyle = {
-    maxHeight: "unset",
-  };
+	const preloaderStyle = {
+		maxHeight: 'unset',
+	};
 
-  return (
-    <>
-      <HashRouter>
-        <Suspense fallback={<Preloader style={preloaderStyle} />}>
-          {dataFetched ? (
-            <ThemeProvider theme={theme}>
-              <Routes>
-                {adminRoutes.map((routeItem, index) => {
-                  return (
-                    <Route
-                      key={index}
-                      path={routeItem.path}
-                      element={routeItem.element}
-                    ></Route>
-                  );
-                })}
-              </Routes>
-            </ThemeProvider>
-          ) : (
-            <Preloader type="full" style={preloaderStyle} />
-          )}
-        </Suspense>
-      </HashRouter>
-    </>
-  );
+	return (
+		<>
+			<HashRouter>
+				<Suspense fallback={ <Preloader style={ preloaderStyle } /> }>
+					{ dataFetched ? (
+						<ThemeProvider theme={ theme }>
+							<Routes>
+								{ adminRoutes.map( ( routeItem, index ) => {
+									return (
+										<Route
+											key={ index }
+											path={ routeItem.path }
+											element={ routeItem.element }
+										></Route>
+									);
+								} ) }
+							</Routes>
+						</ThemeProvider>
+					) : (
+						<Preloader type="full" style={ preloaderStyle } />
+					) }
+				</Suspense>
+			</HashRouter>
+		</>
+	);
 }
 
-function initializeApp(container) {
-  if (createRoot) {
-    const root = createRoot(container);
+function initializeApp( container ) {
+	if ( createRoot ) {
+		const root = createRoot( container );
 
-    root.render(
-      <div>
-        <Suspense fallback={<Preloader />}>
-          <App />
-        </Suspense>
-      </div>
-    );
-  } else {
-    render(
-      <div>
-        <Suspense fallback={<Preloader />}>
-          <App />
-        </Suspense>
-      </div>,
-      container
-    );
-  }
+		root.render(
+			<div>
+				<Suspense fallback={ <Preloader /> }>
+					<App />
+				</Suspense>
+			</div>
+		);
+	} else {
+		render(
+			<div>
+				<Suspense fallback={ <Preloader /> }>
+					<App />
+				</Suspense>
+			</div>,
+			container
+		);
+	}
 }
 
-document.addEventListener("DOMContentLoaded", function () {
-  const container = document.querySelector("#ba-dashboard-app");
+document.addEventListener( 'DOMContentLoaded', function () {
+	const container = document.querySelector( '#ba-dashboard-app' );
 
-  if (!container) {
-    return;
-  }
+	if ( ! container ) {
+		return;
+	}
 
-  initializeApp(container);
-});
+	initializeApp( container );
+} );

--- a/resources/js/layout/Sidebar/index.js
+++ b/resources/js/layout/Sidebar/index.js
@@ -1,132 +1,150 @@
-import { useEffect, useState } from "@wordpress/element";
-import ReactSVG from "react-inlinesvg";
-import menuIcon from "@icon/reader.svg";
+import { useEffect, useState } from '@wordpress/element';
+import ReactSVG from 'react-inlinesvg';
+import menuIcon from '@icon/reader.svg';
 
-const Sidebar = (props) => {
-  const [activeSection, setActiveSection] = useState("");
-  const [isSidebarFixed, setIsSidebarFixed] = useState(false);
+const Sidebar = ( props ) => {
+	const [ activeSection, setActiveSection ] = useState( '' );
+	const [ isSidebarFixed, setIsSidebarFixed ] = useState( false );
 
-  const { page } = props;
+	const { page } = props;
 
-  // Determine which sections to display based on the current page. This keeps
-  // the navigation focused and relevant.
-  const sections =
-    page === "pluginDetails"
-      ? [
-          {
-            id: "ba-dashboard__styles_scripts",
-            name: "Assets",
-          },
-        ]
-      : page === "postDetails"
-      ? [
-          {
-            id: "ba-dashboard__post_summary",
-            name: "Summary",
-          },
-          {
-            id: "ba-dashboard__registered_post_types",
-            name: "Registered",
-          },
-          {
-            id: "ba-dashboard__orphan_post_types",
-            name: "Orphaned",
-          },
-        ]
-      : [
-          {
-            id: "ba-dashboard__post",
-            name: "Post Types",
-          },
-          {
-            id: "ba-dashboard__database",
-            name: "Database",
-          },
-          {
-            id: "ba-dashboard__plugins",
-            name: "Plugins",
-          },
-          ...(boltaudit_data?.hasWooCommerce
-            ? [
-                {
-                  id: "ba-dashboard__woocommerce",
-                  name: "WooCommerce",
-                },
-              ]
-            : []),
-          {
-            id: "ba-dashboard__environment",
-            name: "Environment",
-          },
-        ];
+	// Determine which sections to display based on the current page. This keeps
+	// the navigation focused and relevant.
+	const sections =
+		page === 'pluginDetails'
+			? [
+					{
+						id: 'ba-dashboard__styles_scripts',
+						name: 'Assets',
+					},
+			  ]
+			: page === 'postDetails'
+			? [
+					{
+						id: 'ba-dashboard__post_summary',
+						name: 'Summary',
+					},
+					{
+						id: 'ba-dashboard__registered_post_types',
+						name: 'Registered',
+					},
+					{
+						id: 'ba-dashboard__orphan_post_types',
+						name: 'Orphaned',
+					},
+			  ]
+			: page === 'wooDetails'
+			? [
+					{
+						id: 'ba-dashboard__woo_summary',
+						name: 'Summary',
+					},
+					{
+						id: 'ba-dashboard__woo_insights',
+						name: 'Performance',
+					},
+			  ]
+			: [
+					{
+						id: 'ba-dashboard__post',
+						name: 'Post Types',
+					},
+					{
+						id: 'ba-dashboard__database',
+						name: 'Database',
+					},
+					{
+						id: 'ba-dashboard__plugins',
+						name: 'Plugins',
+					},
+					...( boltaudit_data?.hasWooCommerce
+						? [
+								{
+									id: 'ba-dashboard__woocommerce',
+									name: 'WooCommerce',
+								},
+						  ]
+						: [] ),
+					{
+						id: 'ba-dashboard__environment',
+						name: 'Environment',
+					},
+			  ];
 
-  // Scroll to the selected section without altering the hash based route. When
-  // using a HashRouter the application route lives in the URL hash. Linking
-  // directly to `#section` would overwrite that route and bounce the user back
-  // to the overview page. Instead we intercept the click, update the active
-  // state, and smoothly scroll to the relevant element.
-  function handleSection(item) {
-    setActiveSection(item);
+	// Scroll to the selected section without altering the hash based route. When
+	// using a HashRouter the application route lives in the URL hash. Linking
+	// directly to `#section` would overwrite that route and bounce the user back
+	// to the overview page. Instead we intercept the click, update the active
+	// state, and smoothly scroll to the relevant element.
+	function handleSection( item ) {
+		setActiveSection( item );
 
-    const el = document.getElementById(item);
-    if (el) {
-      window.requestAnimationFrame(() => {
-        el.scrollIntoView({ behavior: "smooth", block: "start" });
-      });
-    }
-  }
+		const el = document.getElementById( item );
+		if ( el ) {
+			window.requestAnimationFrame( () => {
+				el.scrollIntoView( { behavior: 'smooth', block: 'start' } );
+			} );
+		}
+	}
 
-  useEffect(() => {
-    const sectionIds = sections.map((section) => section.id);
+	useEffect( () => {
+		const sectionIds = sections.map( ( section ) => section.id );
 
-    const handleScroll = () => {
-      const scrollPosition = window.scrollY + 100;
+		const handleScroll = () => {
+			const scrollPosition = window.scrollY + 100;
 
-      let current = sectionIds[0];
-      for (let id of sectionIds) {
-        const el = document.getElementById(id);
-        if (el && el.offsetTop <= scrollPosition) {
-          current = id;
-        }
-      }
-      setActiveSection(current);
+			let current = sectionIds[ 0 ];
+			for ( let id of sectionIds ) {
+				const el = document.getElementById( id );
+				if ( el && el.offsetTop <= scrollPosition ) {
+					current = id;
+				}
+			}
+			setActiveSection( current );
 
-      setIsSidebarFixed(window.scrollY >= 200);
-    };
+			setIsSidebarFixed( window.scrollY >= 200 );
+		};
 
-    window.addEventListener("scroll", handleScroll);
-    handleScroll(); // initialize on mount
+		window.addEventListener( 'scroll', handleScroll );
+		handleScroll(); // initialize on mount
 
-    return () => window.removeEventListener("scroll", handleScroll);
-  }, [sections]); // include in dependency
+		return () => window.removeEventListener( 'scroll', handleScroll );
+	}, [ sections ] ); // include in dependency
 
-  return (
-    <aside
-      className={`ba-dashboard__sidebar ${
-        isSidebarFixed ? "sidebar-fixed" : ""
-      }`}
-    >
-      <ul className="ba-dashboard__sidebar__menu">
-        {sections.map((section) => (
-          <li key={section.id} className="ba-dashboard__sidebar__menu__item">
-            <a
-              href="#"
-              className={`ba-dashboard__sidebar__menu__link ${
-                activeSection === section.id ? "active" : ""
-              }`}
-              onClick={(e) => {
-                e.preventDefault();
-                handleSection(section.id);
-              }}
-            >
-              <ReactSVG src={menuIcon} width={20} height={20} />
-              {section.name}
-            </a>
-          </li>
-        ))}
-      </ul>
-    </aside>
-  );
+	return (
+		<aside
+			className={ `ba-dashboard__sidebar ${
+				isSidebarFixed ? 'sidebar-fixed' : ''
+			}` }
+		>
+			<ul className="ba-dashboard__sidebar__menu">
+				{ sections.map( ( section ) => (
+					<li
+						key={ section.id }
+						className="ba-dashboard__sidebar__menu__item"
+					>
+						<a
+							href="#"
+							className={ `ba-dashboard__sidebar__menu__link ${
+								activeSection === section.id ? 'active' : ''
+							}` }
+							onClick={ ( e ) => {
+								e.preventDefault();
+								handleSection( section.id );
+							} }
+						>
+							<ReactSVG
+								src={ menuIcon }
+								width={ 20 }
+								height={ 20 }
+							/>
+							{ section.name }
+						</a>
+					</li>
+				) ) }
+			</ul>
+		</aside>
+	);
 };
 
 export default Sidebar;

--- a/resources/js/modules/HomepageContent/WoocommerceSection.js
+++ b/resources/js/modules/HomepageContent/WoocommerceSection.js
@@ -1,161 +1,169 @@
-import ContentLoading from "@components/ContentLoading";
-import CountUp from "@components/CountUp";
-import postData from "@helper/postData";
+import ContentLoading from '@components/ContentLoading';
+import CountUp from '@components/CountUp';
+import postData from '@helper/postData';
 import ReactSVG from 'react-inlinesvg';
-import { useEffect, useState } from "@wordpress/element";
+import { useEffect, useState } from '@wordpress/element';
+import { Link } from 'react-router-dom';
 
 import arrowRightIcon from '@icon/arrow-right.svg';
 
 export default function WoocommerceSection() {
-  const [data, setData] = useState(null);
+	const [ data, setData ] = useState( null );
 
-  useEffect(() => {
-    postData("boltaudit/reports/woocommerce").then((res) => {
-      setData(res);
-    });
-  }, []);
+	useEffect( () => {
+		postData( 'boltaudit/reports/woocommerce' ).then( ( res ) => {
+			setData( res );
+		} );
+	}, [] );
 
-  if (!data) {
-    return <ContentLoading />;
-  }
+	if ( ! data ) {
+		return <ContentLoading />;
+	}
 
-  const summary = data.summary || {};
-  const insights = data.insights || {};
+	const summary = data.summary || {};
+	const insights = data.insights || {};
 
-  const rows = [
-    {
-      label: "HPOS Enabled",
-      description:
-        "Indicates if High Performance Order Storage feature is active.",
-      value: insights.hpos_enabled ? "✅" : "❌",
-    },
-    {
-      label: "Scheduled Actions",
-      description: "Number of pending actions in ActionScheduler.",
-      value: insights.scheduled_actions,
-    },
-    {
-      label: "High Product Variation Count",
-      description: "Warns when product variations exceed 2,000.",
-      value: insights.high_variation_count ? "⚠️" : "✅",
-    },
-    {
-      label: "Outdated Woo Templates",
-      description: "Theme overrides of WooCommerce templates that are outdated.",
-      value:
-        insights.outdated_templates && insights.outdated_templates.length > 0
-          ? "⚠️"
-          : "✅",
-    },
-    {
-      label: "Unused Product Tags",
-      description: "Tags without any products attached.",
-      value:
-        insights.unused_product_tags > 0
-          ? `${insights.unused_product_tags} ⚠️`
-          : "✅",
-    },
-    {
-      label: "Woo Styles/JS on All Pages",
-      description:
-        "Checks if WooCommerce scripts and styles are enqueued globally.",
-      value: insights.styles_js_global ? "❌" : "✅",
-    },
-    {
-      label: "Transients (wc_*)",
-      description: "Count of WooCommerce transients in wp_options.",
-      value:
-        insights.wc_transients > 0
-          ? `${insights.wc_transients} ⚠️`
-          : "✅",
-    },
-    {
-      label: "Cart Fragments Sitewide",
-      description:
-        "Detects if wc-ajax=get_refreshed_fragments loads on every page, which hurts caching.",
-      value: insights.cart_fragments_sitewide ? "❌" : "✅",
-    },
-  ];
+	const rows = [
+		{
+			label: 'HPOS Enabled',
+			description:
+				'Indicates if High Performance Order Storage feature is active.',
+			value: insights.hpos_enabled ? '✅' : '❌',
+		},
+		{
+			label: 'Scheduled Actions',
+			description: 'Number of pending actions in ActionScheduler.',
+			value: insights.scheduled_actions,
+		},
+		{
+			label: 'High Product Variation Count',
+			description: 'Warns when product variations exceed 2,000.',
+			value: insights.high_variation_count ? '⚠️' : '✅',
+		},
+		{
+			label: 'Outdated Woo Templates',
+			description:
+				'Theme overrides of WooCommerce templates that are outdated.',
+			value:
+				insights.outdated_templates &&
+				insights.outdated_templates.length > 0
+					? '⚠️'
+					: '✅',
+		},
+		{
+			label: 'Unused Product Tags',
+			description: 'Tags without any products attached.',
+			value:
+				insights.unused_product_tags > 0
+					? `${ insights.unused_product_tags } ⚠️`
+					: '✅',
+		},
+		{
+			label: 'Woo Styles/JS on All Pages',
+			description:
+				'Checks if WooCommerce scripts and styles are enqueued globally.',
+			value: insights.styles_js_global ? '❌' : '✅',
+		},
+		{
+			label: 'Transients (wc_*)',
+			description: 'Count of WooCommerce transients in wp_options.',
+			value:
+				insights.wc_transients > 0
+					? `${ insights.wc_transients } ⚠️`
+					: '✅',
+		},
+		{
+			label: 'Cart Fragments Sitewide',
+			description:
+				'Detects if wc-ajax=get_refreshed_fragments loads on every page, which hurts caching.',
+			value: insights.cart_fragments_sitewide ? '❌' : '✅',
+		},
+	];
 
-  return (
-    <div id="ba-dashboard__woocommerce" className="ba-dashboard__content__section">
-      <h4 className="ba-dashboard__content__section__title">
-        WooCommerce Insights
-      </h4>
-      <p className="ba-dashboard__content__section__desc">
-        A clear performance snapshot of your store. Detect outdated templates, global asset bloat, unused data, and behaviors that quietly hurt speed and scalability.
-      </p>
-      <a href="#" className="ba-dashboard__content__overview__btn ba-dashboard__btn">
-        <span className="bs-dashboard-tooltip">
-           Open Detailed Report{ ' ' }
-            <ReactSVG
-              src={ arrowRightIcon }
-              width={ 16 }
-              height={ 16 }
-            />
-          <span className="bs-dashboard-tooltip-content">
-            Upcoming
-          </span>
-        </span>
-      </a>
-      <div className="ba-dashboard__content__section__content">
-        <div className="ba-dashboard__content__section__overview equal-height">
-          <div className="ba-dashboard__content__section__overview__single">
-            <span className="ba-dashboard__content__section__overview__title">Products</span>
-            <span className="ba-dashboard__content__section__overview__count">
-              {summary.products || 0}
-            </span>
-          </div>
-          <div className="ba-dashboard__content__section__overview__single">
-            <span className="ba-dashboard__content__section__overview__title">Variations</span>
-            <span className="ba-dashboard__content__section__overview__count">
-              {summary.variations || 0}
-            </span>
-          </div>
-          <div className="ba-dashboard__content__section__overview__single">
-            <span className="ba-dashboard__content__section__overview__title">Orders</span>
-            <span className="ba-dashboard__content__section__overview__count">
-             {summary.orders || 0} 
-            </span>
-          </div>
-          <div className="ba-dashboard__content__section__overview__single">
-            <span className="ba-dashboard__content__section__overview__title">Coupons</span>
-            <span className="ba-dashboard__content__section__overview__count">
-              {summary.coupons || 0}
-            </span>
-          </div>
-          <div className="ba-dashboard__content__section__overview__single">
-            <span className="ba-dashboard__content__section__overview__title">Categories</span>
-            <span className="ba-dashboard__content__section__overview__count">
-              {summary.categories || 0}
-            </span>
-          </div>
-          <div className="ba-dashboard__content__section__overview__single">
-            <span className="ba-dashboard__content__section__overview__title">Attributes/Terms</span>
-            <span className="ba-dashboard__content__section__overview__count">
-              {summary.attribute_terms || 0}
-            </span>
-          </div>
-        </div>
-        <div className="ba-dashboard__content__section__data">
-          <table>
-            <thead>
-              <tr>
-                <th className="feature">Feature</th>
-                <th className="description">Description</th>
-              </tr>
-            </thead>
-            <tbody>
-              {rows.map((row, idx) => (
-                <tr key={idx}>
-                  <td className="feature">{row.label} — {row.value}</td>
-                  <td className="description">{row.description}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      </div>
-    </div>
-  );
+	return (
+		<div
+			id="ba-dashboard__woocommerce"
+			className="ba-dashboard__content__section"
+		>
+			<h4 className="ba-dashboard__content__section__title">
+				WooCommerce Insights
+			</h4>
+			<p className="ba-dashboard__content__section__desc">
+				A clear performance snapshot of your store. Detect outdated
+				templates, global asset bloat, unused data, and behaviors that
+				quietly hurt speed and scalability.
+			</p>
+			<Link
+				to="/woocommerce"
+				className="ba-dashboard__content__overview__btn ba-dashboard__btn"
+			>
+				<span className="bs-dashboard-tooltip">
+					Open Detailed Report{ ' ' }
+					<ReactSVG
+						src={ arrowRightIcon }
+						width={ 16 }
+						height={ 16 }
+					/>
+				</span>
+			</Link>
+			<div className="ba-dashboard__content__section__content">
+				<div className="ba-dashboard__content__section__overview equal-height">
+					<div className="ba-dashboard__content__section__overview__single">
+						<span className="ba-dashboard__content__section__overview__title">
+							Products
+						</span>
+						<span className="ba-dashboard__content__section__overview__count">
+							<CountUp target={ summary.products || 0 } />
+						</span>
+					</div>
+					<div className="ba-dashboard__content__section__overview__single">
+						<span className="ba-dashboard__content__section__overview__title">
+							Variations
+						</span>
+						<span className="ba-dashboard__content__section__overview__count">
+							<CountUp target={ summary.variations || 0 } />
+						</span>
+					</div>
+					<div className="ba-dashboard__content__section__overview__single">
+						<span className="ba-dashboard__content__section__overview__title">
+							Orders
+						</span>
+						<span className="ba-dashboard__content__section__overview__count">
+							<CountUp target={ summary.orders || 0 } />
+						</span>
+					</div>
+					<div className="ba-dashboard__content__section__overview__single">
+						<span className="ba-dashboard__content__section__overview__title">
+							Coupons
+						</span>
+						<span className="ba-dashboard__content__section__overview__count">
+							<CountUp target={ summary.coupons || 0 } />
+						</span>
+					</div>
+				</div>
+				<div className="ba-dashboard__content__section__data">
+					<table>
+						<thead>
+							<tr>
+								<th className="feature">Feature</th>
+								<th className="description">Description</th>
+							</tr>
+						</thead>
+						<tbody>
+							{ rows.map( ( row, idx ) => (
+								<tr key={ idx }>
+									<td className="feature">
+										{ row.label } — { row.value }
+									</td>
+									<td className="description">
+										{ row.description }
+									</td>
+								</tr>
+							) ) }
+						</tbody>
+					</table>
+				</div>
+			</div>
+		</div>
+	);
 }

--- a/resources/js/modules/WooDetailsContent/OverviewSection.js
+++ b/resources/js/modules/WooDetailsContent/OverviewSection.js
@@ -1,0 +1,42 @@
+import CountUp from '@components/CountUp';
+
+export default function OverviewSection( { summary } ) {
+	const items = [
+		{ label: 'Products', value: summary.products || 0 },
+		{ label: 'Variations', value: summary.variations || 0 },
+		{ label: 'Orders', value: summary.orders || 0 },
+		{ label: 'Coupons', value: summary.coupons || 0 },
+		{ label: 'Categories', value: summary.categories || 0 },
+		{ label: 'Attributes/Terms', value: summary.attribute_terms || 0 },
+	];
+
+	return (
+		<div
+			id="ba-dashboard__woo_summary"
+			className="ba-dashboard__content__section"
+		>
+			<h4 className="ba-dashboard__content__section__title">
+				WooCommerce Summary
+			</h4>
+			<p className="ba-dashboard__content__section__desc">
+				Snapshot of your store's scale including products, orders and
+				taxonomy counts.
+			</p>
+			<div className="ba-dashboard__content__section__overview">
+				{ items.map( ( item ) => (
+					<div
+						className="ba-dashboard__content__section__overview__single"
+						key={ item.label }
+					>
+						<span className="ba-dashboard__content__section__overview__title">
+							{ item.label }
+						</span>
+						<span className="ba-dashboard__content__section__overview__count">
+							<CountUp target={ item.value } />
+						</span>
+					</div>
+				) ) }
+			</div>
+		</div>
+	);
+}

--- a/resources/js/modules/WooDetailsContent/PerformanceSection.js
+++ b/resources/js/modules/WooDetailsContent/PerformanceSection.js
@@ -1,0 +1,114 @@
+export default function PerformanceSection( { insights } ) {
+	const rows = [
+		{
+			label: 'HPOS Enabled',
+			description:
+				'Indicates if High Performance Order Storage feature is active.',
+			value: insights.hpos_enabled ? 'Yes' : 'No',
+		},
+		{
+			label: 'Scheduled Actions',
+			description: 'Number of pending actions in ActionScheduler.',
+			value: insights.scheduled_actions,
+		},
+		{
+			label: 'High Product Variation Count',
+			description: 'Warns when product variations exceed 2,000.',
+			value: insights.high_variation_count ? 'Yes' : 'No',
+		},
+		{
+			label: 'Unused Product Tags',
+			description: 'Tags without any products attached.',
+			value: insights.unused_product_tags,
+		},
+		{
+			label: 'Woo Styles/JS on All Pages',
+			description:
+				'Checks if WooCommerce scripts and styles are enqueued globally.',
+			value: insights.styles_js_global ? 'Yes' : 'No',
+		},
+		{
+			label: 'Transients (wc_*)',
+			description: 'Count of WooCommerce transients in wp_options.',
+			value: insights.wc_transients,
+		},
+		{
+			label: 'Cart Fragments Sitewide',
+			description:
+				'Detects if wc-ajax=get_refreshed_fragments loads on every page, which hurts caching.',
+			value: insights.cart_fragments_sitewide ? 'Yes' : 'No',
+		},
+	];
+
+	return (
+		<div
+			id="ba-dashboard__woo_insights"
+			className="ba-dashboard__content__section"
+		>
+			<h4 className="ba-dashboard__content__section__title">
+				Performance Features
+			</h4>
+			<p className="ba-dashboard__content__section__desc">
+				Review behaviors and settings that may be affecting WooCommerce
+				performance.
+			</p>
+			<div className="ba-dashboard__content__section__data">
+				<table>
+					<thead>
+						<tr>
+							<th className="feature">Feature</th>
+							<th className="description">Description</th>
+						</tr>
+					</thead>
+					<tbody>
+						{ rows.map( ( row, idx ) => (
+							<tr key={ idx }>
+								<td className="feature">
+									{ row.label } — { row.value }
+								</td>
+								<td className="description">
+									{ row.description }
+								</td>
+							</tr>
+						) ) }
+					</tbody>
+				</table>
+			</div>
+			{ insights.outdated_templates &&
+				insights.outdated_templates.length > 0 && (
+					<div
+						className="ba-dashboard__content__section__data"
+						id="ba-dashboard__woo_outdated_templates"
+					>
+						<h5>Outdated Templates</h5>
+						<table>
+							<thead>
+								<tr>
+									<th>Template</th>
+									<th>Version</th>
+									<th>Core Version</th>
+								</tr>
+							</thead>
+							<tbody>
+								{ insights.outdated_templates.map(
+									( tpl, i ) => (
+										<tr key={ i }>
+											<td>
+												{ tpl.file || tpl.template }
+											</td>
+											<td>
+												{ tpl.version ||
+													tpl.file_version ||
+													'-' }
+											</td>
+											<td>{ tpl.core_version || '-' }</td>
+										</tr>
+									)
+								) }
+							</tbody>
+						</table>
+					</div>
+				) }
+		</div>
+	);
+}

--- a/resources/js/modules/WooDetailsContent/index.js
+++ b/resources/js/modules/WooDetailsContent/index.js
@@ -1,0 +1,22 @@
+import ContentLoading from '@components/ContentLoading';
+import { lazy, Suspense } from '@wordpress/element';
+
+const OverviewSection = lazy( () => import( './OverviewSection' ) );
+const PerformanceSection = lazy( () => import( './PerformanceSection' ) );
+
+export default function WooDetailsModule( { data } ) {
+	if ( ! data ) {
+		return <ContentLoading />;
+	}
+
+	return (
+		<>
+			<Suspense fallback={ <ContentLoading /> }>
+				<OverviewSection summary={ data.summary || {} } />
+			</Suspense>
+			<Suspense fallback={ <ContentLoading /> }>
+				<PerformanceSection insights={ data.insights || {} } />
+			</Suspense>
+		</>
+	);
+}

--- a/resources/js/pages/WooCommerceDetails.js
+++ b/resources/js/pages/WooCommerceDetails.js
@@ -1,0 +1,39 @@
+import postData from '@helper/postData';
+import AppLayout from '@layout/AppLayout';
+import HomepageContentSidebarModule from '@modules/HomepageContentSidebar';
+import WooDetailsModule from '@modules/WooDetailsContent';
+import { useEffect, useState } from '@wordpress/element';
+
+const WooCommerceDetailsPage = () => {
+	const [ data, setData ] = useState( null );
+
+	useEffect( () => {
+		let cancelled = false;
+
+		async function fetchData() {
+			const res = await postData( 'boltaudit/reports/woocommerce' );
+			if ( ! cancelled ) {
+				setData( res );
+			}
+		}
+
+		fetchData();
+
+		return () => {
+			cancelled = true;
+		};
+	}, [] );
+
+	return (
+		<AppLayout type="detailsHeader" page="wooDetails">
+			<div className="ba-dashboard__content">
+				<div className="ba-dashboard__content__wrapper">
+					<WooDetailsModule data={ data } />
+				</div>
+				<HomepageContentSidebarModule />
+			</div>
+		</AppLayout>
+	);
+};
+
+export default WooCommerceDetailsPage;


### PR DESCRIPTION
## Summary
- add WooCommerce details page with summary and performance sections
- expose new route and sidebar navigation for WooCommerce reports
- show only four key WooCommerce metrics on overview and link to details

## Testing
- `npm test` *(fails: Missing script "test")*
- `composer phpcs` *(fails: Missing file doc comment in enqueues/admin-enqueue.php)*

------
https://chatgpt.com/codex/tasks/task_e_689882db723883328c457e8d3adb67ae